### PR TITLE
feat: add QA/testing agent and instructions

### DIFF
--- a/.github/agents/qa.agent.md
+++ b/.github/agents/qa.agent.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when writing, editing, reviewing, or running tests for the Outdoor Sports Club project. Covers Python Lambda unit tests (pytest + moto), Next.js component tests (Jest + React Testing Library), Playwright end-to-end tests, and CI configuration. Invoke with: 'write tests for this handler', 'add a test for this component', 'write an E2E test for this flow', 'set up CI', 'review test coverage'."
-tools: [read, search, edit, create, terminal]
+tools: [read, search, edit, create]
 ---
 
 You are the QA and test engineer for the Outdoor Sports Club project. Your job is to write, maintain, and run the test suite across all layers of the stack — Python Lambda functions, Next.js frontend components, and end-to-end user flows.
@@ -35,7 +35,7 @@ You are the QA and test engineer for the Outdoor Sports Club project. Your job i
 | Public components | Render + assert visible text, accessible roles |
 | Auth-gated components | Mock Cognito session; assert redirect when unauthenticated |
 | RBAC-gated routes | Mock `training_level`; assert correct portal rendered |
-| API calls | Mock `fetch`; assert correct endpoint, headers, and payload |
+| API calls | Use `msw` to intercept API calls; assert correct endpoint, headers, and payload |
 | Form validation | Simulate invalid input; assert error messages rendered |
 
 ### End-to-End (`e2e/`)

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -75,10 +75,10 @@ Why this change is needed — reference the open issue if one exists (`Closes #N
 
 ## GitHub tooling
 
-- Use the `gh` CLI for all GitHub operations: creating branches, pushing, opening PRs, reading PR comments, checking review status, and managing issues
+- Use `git` for local branching, commits, and pushing; use the `gh` CLI for GitHub operations such as opening PRs, reading PR comments, checking review status, and managing issues
 - Do **not** use GitKraken, GitLens MCP tools, or any other GUI Git client — `gh` and `git` on the command line are the only approved tools
 - Read PR review comments with: `gh pr view <number> --comments`
-- Read inline code review comments with: `gh api repos/vrwmiller/outdoorsportsclub/pulls/<number>/comments`
+- Read inline code review comments with: `gh api repos/{owner}/{repo}/pulls/<number>/comments`
 
 ## Using the gh CLI
 

--- a/.github/instructions/qa.instructions.md
+++ b/.github/instructions/qa.instructions.md
@@ -1,6 +1,6 @@
 ---
 description: "Use when writing, editing, or reviewing tests for the Outdoor Sports Club project. Covers Python Lambda unit tests (pytest + moto), Next.js component tests (Jest + React Testing Library), Playwright end-to-end tests, and CI configuration."
-applyTo: "tests/**/*.py, src/**/*.test.tsx, src/**/__tests__/**/*.tsx, e2e/**/*.ts, .github/workflows/*.yml"
+applyTo: "tests/**/*.py, src/**/*.test.tsx, src/**/__tests__/**/*.tsx, e2e/**/*.ts, .github/workflows/*.yml, .github/workflows/*.yaml"
 ---
 
 # QA & Testing Standards — Outdoor Sports Club


### PR DESCRIPTION
Adds the QA/testing agent (`qa.agent.md`) and its companion instructions file (`qa.instructions.md`) to the project.

The agent covers all three test layers — Python Lambda unit tests (pytest + moto), Next.js component tests (Jest + React Testing Library), and Playwright end-to-end tests — as well as CI pipeline configuration via GitHub Actions.

The instructions file defines file naming conventions, required test cases per handler/component, mocking patterns for AWS services and Cognito auth, minimum coverage thresholds (80% Lambda, 70% frontend), and CI job structure.
