### PR TITLE
feat: multi-region HA by design with variable region count

### DIFF
--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -21,7 +21,7 @@ applyTo: "infra/**/*.yaml, infra/**/*.json, amplify/**/*.ts, amplify/**/*.yaml"
 | **Amazon Route 53** | Latency-based or failover routing across regional API Gateway endpoints |
 | **Amazon SNS** | SMS alerts topic |
 | **Amazon CloudWatch** | Lambda logs, API Gateway access logs |
-| **AWS Backup** | Aurora PITR (35-day) + daily cross-region replication to `us-west-2` |
+| **AWS Backup** | Aurora PITR (35-day) + daily cross-region copy to all regions in `RegionList` |
 
 ## File Layout
 
@@ -166,7 +166,7 @@ Use `!Select [0, !Ref RegionList]` to reference the primary region. Use `Conditi
 
 ```yaml
 Conditions:
-  IsMultiRegion: !Not [!Equals [!Select [1, !Split [",", !Join [",", [!Join [",", !Ref RegionList], ",SENTINEL"]]]], "SENTINEL"]]
+  IsMultiRegion: !Not [!Equals [!Select [1, !Split [",", !Join [",", [!Join [",", !Ref RegionList], "SENTINEL"]]]], "SENTINEL"]]
 ```
 
 Only provision cross-region resources (Aurora Global Database secondary clusters, KMS replica keys, S3 CRR rules, Secrets Manager replicas, Route 53 failover records) when `IsMultiRegion` is true.

--- a/docs/design.md
+++ b/docs/design.md
@@ -159,9 +159,9 @@ Each active region runs a complete, independent copy of:
 
 | Phase | Region count | Configuration |
 | :--- | :--- | :--- |
-| Development / staging | 1 (primary only) | `RegionList: [us-east-1]` |
-| Production launch | 1 (primary) | `RegionList: [us-east-1]` |
-| Multi-region active-active | 2+ | `RegionList: [us-east-1, us-west-2]` |
+| Development / staging | 1 (primary only) | `RegionList: us-east-1` |
+| Production launch | 1 (primary) | `RegionList: us-east-1` |
+| Multi-region active-active | 2+ | `RegionList: us-east-1,us-west-2` |
 
 All CloudFormation stacks accept a `RegionList` parameter. Cross-region resources (Aurora Global Database secondary clusters, KMS replica keys, S3 CRR rules, Secrets Manager replicas) are conditionally created: if `RegionList` has only one entry, none of the replication resources are provisioned.
 
@@ -173,7 +173,7 @@ All CloudFormation stacks accept a `RegionList` parameter. Cross-region resource
 
 ### The "Red Button" procedure
 
-In a full primary-region failure with active-active enabled: Route 53 automatically promotes a reader region. In single-region mode: the Webmaster deploys the stack to a new region using the IaC parameters and the latest Aurora Global Database snapshot. Target RTO: under 60 minutes from a cold start.
+In a full primary-region failure with active-active enabled: **Aurora Global Database** fails over and promotes a reader cluster in a secondary region to writer, and **Route 53** updates DNS to route traffic to the healthy regional endpoint. In single-region mode: the **Webmaster** deploys the stack to a new region using the IaC parameters and restores Aurora from **AWS Backup** or an Aurora point-in-time restore/snapshot. Target RTO: under 60 minutes from a cold start.
 
 ## 9. Open Design Questions
 


### PR DESCRIPTION
## Summary

Establishes multi-region high availability and failover as a first-class design principle. Region count is a deployment-time parameter — going from single-region to active-active multi-region requires a configuration change, not a code or architecture change.

## Changes

- `docs/design.md` — Replaced Section 8 (Backup & DR) with an expanded "High Availability, Multi-Region & Disaster Recovery" section covering: variable region count design principle, per-region stack composition, Aurora Global Database, S3 MRAP + CRR, multi-region KMS keys, Secrets Manager replication, Route 53 latency/failover routing, and deployment phase table
- `.github/instructions/infra.instructions.md` — Added "Multi-Region Design" section specifying the `RegionList` CloudFormation parameter, `IsMultiRegion` condition pattern, per-region resource table, traffic routing rules, and single-region default behavior; updated AWS services table to include Route 53, Aurora Global Database, S3 MRAP, multi-region KMS and Secrets Manager

## Motivation

Payment processing must not be lost or duplicated during a regional failure. By parameterizing region count from the start, the IaC can scale to active-active without rework. Initial and staging deployments remain single-region (`RegionList: "us-east-1"`) to minimize cost.

## Security considerations

- Multi-region KMS keys (`mrk-` prefix) replicate key material across regions — key policies must be applied identically in each region
- S3 Cross-Region Replication preserves Object Lock (Compliance Mode) on replicated waiver objects
- No new IAM permissions added in this PR — this is design/spec only, no IaC code yet

## Testing

Design and instructions changes only — no deployable infrastructure in this PR. Verified that the `RegionList` CloudFormation condition pattern renders correctly.

## Breaking changes

None — no infrastructure has been deployed yet.
