### PR TITLE
fix: clarify branch naming — no username or org prefix

### DIFF
--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -8,6 +8,7 @@ applyTo: "**"
 
 - Never commit directly to `main` — all changes go on a feature branch
 - Branch names must be descriptive: `feat/<topic>`, `fix/<topic>`, `chore/<topic>`
+- `<topic>` uses only lowercase letters, numbers, and hyphens — never a username, org name, or repo name prefix
 - Open a PR to merge into `main`
 
 ## PR title format


### PR DESCRIPTION
Adds an explicit rule that `<topic>` in branch names uses only lowercase letters, numbers, and hyphens — never a username, org name, or repo name prefix.

The previous rule only specified the `feat/`, `fix/`, `chore/` prefixes without clarifying what was allowed (or forbidden) in the topic segment. This closes the gap.
