### PR TITLE
chore: ignore LICENSE in markdownlint

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+# LICENSE is verbatim GPL v3 legal text and must not be modified
+LICENSE


### PR DESCRIPTION
Adds `.markdownlintignore` to suppress lint warnings on the LICENSE file. LICENSE is verbatim GPL v3 legal text that cannot be modified, so markdownlint rules (MD041, MD029, MD038, etc.) are not applicable.
