### PR TITLE
feat: add home_phone and mobile_phone to members schema

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -59,7 +59,7 @@ The database utilizes a relational model (PostgreSQL) with **Row-Level Security 
 | `waiver_signed_at` | TIMESTAMP | Used to calculate the 1-year automated expiration. |
 | `dues_paid_until` | DATE | Date-based flag for membership standing. |
 | `home_phone` | TEXT (Nullable) | Home telephone number. |
-| `mobile_phone` | TEXT (Nullable) | Mobile number; used by **Amazon SNS** to deliver SMS range alerts. |
+| `mobile_phone` | TEXT (Nullable) | Mobile number in E.164 format (e.g., `+15551234567`); validated/normalized for **Amazon SNS** delivery of SMS range alerts. |
 
 ### **5.2 Table: `devices` (Kiosks)**
 


### PR DESCRIPTION
Adds `home_phone` and `mobile_phone` columns to the `members` schema in `docs/design.md`.

Both fields are nullable TEXT. `mobile_phone` is the number used by Amazon SNS to deliver SMS range alerts to members.
