### PR TITLE
docs: add RSO Focus ROI bullet to executive summary

### DIFF
--- a/docs/one-pager.md
+++ b/docs/one-pager.md
@@ -12,6 +12,7 @@ A unified, low-maintenance platform built on **Amazon Web Services (AWS)**. By u
 
 * **Fiscal Security:** Shifting guest and tournament fees to a **cashless-first model** minimizes physical currency at remote ranges and creates an immutable digital audit trail for the Treasurer.
 * **Automated Compliance:** Digital waivers automatically expire annually. The system triggers a mandatory re-sign at the kiosk, ensuring **100% legal coverage** for every person on the firing line.
+* **RSO Focus:** Check-in, waiver verification, and guest payment are handled entirely at the kiosk — no paper to chase, no cash to manage. **Range Safety Officers** can keep their attention on the firing line instead of administrative tasks.
 * **Frictionless Access:** Support for **Social Login (Google/Facebook)** via **AWS Cognito** eliminates password support requests and provides secure, one-click access for members.
 * **Secure Hardware:** Range tablets are authorized via **Secure Pairing Codes**, functioning as trusted appliances that do not require personal member logins on shared hardware.
 * **Technical Continuity:** A dedicated **Webmaster (Level 6)** tier ensures the platform's health and provides a secure **Recovery Protocol** for members who lose access to their primary social accounts.


### PR DESCRIPTION
Adds an "RSO Focus" bullet to the Key ROI Drivers section of the executive summary. Check-in, waiver verification, and guest payment are all handled at the kiosk, so Range Safety Officers can keep their attention on the firing line instead of administrative tasks.
