### PR TITLE
feat: add architect agent

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -11,7 +11,7 @@ You are the system architect for the Outdoor Sports Club project. Your job is to
 | :--- | :--- |
 | **Frontend** | Next.js hosted on AWS Amplify Gen 2 |
 | **API** | AWS API Gateway (REST) + AWS Lambda (Python 3.12) |
-| **Auth — members** | AWS Cognito (Social Login: Google/Facebook); JWT validated in Lambda |
+| **Auth — members** | AWS Cognito (Social Login: Google/Facebook); JWT validity enforced by API Gateway Cognito Authorizer; Lambda enforces RBAC and `training_level` via Aurora |
 | **Auth — kiosks** | Device Token validated in Lambda against `devices` table |
 | **Database** | Amazon Aurora Serverless v2 (PostgreSQL); accessed via RDS Data API; Row-Level Security |
 | **Payments** | Stripe Terminal SDK (Tap to Pay over tablet NFC — no card reader hardware) |


### PR DESCRIPTION
Adds `.github/agents/architect.agent.md` — a new Copilot agent that owns cross-cutting design decisions for the Outdoor Sports Club project.

## Summary

The existing agent roster covers individual implementation layers (backend, database, infra, designer, docs, qa, linter), but no agent owns decisions that *span* layers — e.g., "should this validation live in the Lambda or the DB?", "what's the API contract for this new feature?", or "is this schema change consistent with the rest of the system?" The architect agent fills that gap.

## Changes

- `.github/agents/architect.agent.md` — new agent file defining scope, responsibilities, constraints, approach, and output format

## Motivation

Without an architect agent, cross-layer decisions default to whichever agent is asked first, which can produce inconsistent or conflicting designs. Having an architect agent ensures there is a single, authoritative place to resolve design questions before implementation begins.

## Security considerations

None — this is a docs/config-only change with no effect on auth, RBAC, secrets, or AWS resources.

## Testing

Manually verified the agent file loads correctly in VS Code and that the description, tools, and output format templates are consistent with the existing agent conventions.

## Breaking changes

None.
