### PR TITLE
feat: resolve ODQ #5 and #12; add ranges, lane mgmt, training_level_policies, and guest schema

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -90,7 +90,7 @@ The database utilizes a relational model (PostgreSQL) with **Row-Level Security 
 
 ### **5.2 Table: `ranges`**
 
-Each staffed range has a row in this table. The `ranges` table is the authoritative source for open/close state and access requirements. Unstaffed ranges (outdoor Archery, Air Rifle when unstaffed) do not have kiosks and do not appear here.
+All physical ranges have a row in this table, regardless of whether they are currently staffed. The `ranges` table is the authoritative source for open/close state and access requirements. Unstaffed ranges (outdoor Archery, Air Rifle when unstaffed) do not have kiosk devices assigned to them, but they still appear here so that `min_training_level` and `is_open` are centrally managed for all ranges.
 
 | Column | Type | Description |
 | :--- | :--- | :--- |
@@ -229,7 +229,18 @@ One row per range visit per guest. Used to enforce the annual visit limit: a gue
 | `visited_at` | TIMESTAMP | Visit timestamp; used to scope the annual limit check to the current calendar year. |
 | `stripe_payment_intent_id` | TEXT (Nullable) | Stripe Payment Intent ID for the guest fee charged on this visit. Duplicated here for direct reconciliation without joining to `activity_logs`. |
 
-**Annual limit check:** `SELECT COUNT(*) FROM guest_visits WHERE guest_id = $1 AND member_id = $2 AND EXTRACT(YEAR FROM visited_at) = EXTRACT(YEAR FROM NOW())`. If result ≥ 2, the kiosk returns `403 Forbidden`. A `guest_visits` row is inserted only after payment is confirmed.
+**Annual limit check:** Query `guest_visits` using a timestamp range rather than `EXTRACT(YEAR …)` so the `(guest_id, member_id, visited_at)` index is used:
+
+```sql
+SELECT COUNT(*)
+FROM guest_visits
+WHERE guest_id  = $1
+  AND member_id = $2
+  AND visited_at >= date_trunc('year', now() AT TIME ZONE 'UTC')
+  AND visited_at  < date_trunc('year', now() AT TIME ZONE 'UTC') + INTERVAL '1 year';
+```
+
+If the count is ≥ 2, the kiosk returns `403 Forbidden`. All times are stored and compared in UTC. A `guest_visits` row is inserted only after payment is confirmed. To prevent a race condition where two simultaneous guest-payment requests both pass the count check, the check and insert must execute within a single **serializable transaction** (or use `SELECT … FOR UPDATE` on the sponsoring member's lane record to serialize concurrent check-ins for the same member).
 
 **Indexes:**
 
@@ -403,7 +414,7 @@ The review independently confirmed the need for a `ranges` table. Both questions
 * `lanes.range_tag` (TEXT) is replaced by `lanes.range_id` (UUID FK to `ranges.id`).
 * Range open/close is a soft operation: `PATCH /v1/admin/ranges/{range_id}/status` sets `is_open`; existing check-ins are not force-cleared. The RSO physically ensures the range is vacated during the closing procedure.
 * The endpoint is callable from both the **Admin Portal** and the **Kiosk View** RSO dashboard (Level 4+).
-* Initial seed: Rifle-Pistol (17 lanes), Skeet-Trap, Archery, Air-Rifle. All seed as closed. `min_training_level` values TBD.
+* Initial seed: Rifle-Pistol (17 lanes), Skeet-Trap, Air-Rifle, Indoor-Archery, Outdoor-Archery. All seed as closed. `min_training_level` values TBD.
 * Lane counts are seeded in the bootstrap migration; future changes use `POST /v1/admin/lanes` and `PATCH /v1/admin/lanes/{lane_id}` without requiring a migration.
 
 ### Rejected: PWA / offline-first kiosk


### PR DESCRIPTION
## Summary
Resolves ODQ #5 (range open/close), ODQ #12 (lane configuration), and adds the guest schema (tables, policy, and annual limit enforcement). ODQ #16 is narrowed to one remaining question: whether `(first_name, last_name, phone)` is a sufficient unique key for returning guests.

## Changes

- **`docs/design.md`**
  - **Section 5.2 — `ranges` table:** New. Authoritative source for open/close state and per-range `min_training_level`. Seeded with 5 ranges (names provisional); Rifle-Pistol seeds with `min_training_level = 1`.
  - **Section 5.3 — `devices`:** Dropped `min_training_level`; added `range_id` FK to `ranges`.
  - **Section 5.4 — `lanes`:** `range_tag TEXT` replaced with `range_id UUID FK`; constraints and indexes updated; Rifle-Pistol seeds 17 lanes.
  - **Section 5.5 — `activity_logs`:** Added `guest_id UUID FK` (nullable); populated for `Guest-Payment` and guest `Waiver-Signed` events.
  - **Section 5.6 — `training_level_policies`:** New. Scalar per-level constraints (currently `max_guests`); admin-editable without a migration. Seed: Level 1 → 0 guests, Level 3+ → 2 guests.
  - **Section 5.7 — `consumable_purchases`:** Renumbered; added missing column header row.
  - **Section 5.8 — `guests`:** New. Persistent identity record for non-member visitors. Waiver-on-file model: waiver captured on first visit; reused until expired. Lookup key: `(first_name, last_name, phone)`.
  - **Section 5.9 — `guest_visits`:** New. One row per range visit per guest. Drives the annual limit check (≤ 2 per guest-member combination per calendar year). Hard 403 block when limit is reached — no RSO override.
  - **Section 7.1 — check-in endpoint:** Updated validation steps to reference `training_level_policies.max_guests`.
  - **Section 7.1 — guest-payment endpoint:** Updated to describe the full guest add-on flow: lookup/create guest, waiver check, annual limit check, payment, `guest_visits` insert, `activity_logs` entry.
  - **Section 7.2:** Added `PATCH /v1/admin/ranges/{range_id}/status`, `POST /v1/admin/lanes`, `PATCH /v1/admin/lanes/{lane_id}`.
  - **Section 10:** Added "Accepted: Guest identity uses waiver-on-file lookup" entry.
  - **Section 11:** ODQ #5 and #12 marked resolved. ODQ #16 narrowed to one remaining open question (guest lookup key fields).

## Motivation

Resolves ODQ #5, #12, and the bulk of #16 before implementation begins. The guest schema decisions were needed to unblock the check-in Lambda, guest add-on kiosk flow, and database migration authoring.

Related to #5, #12, #16.

## Security considerations

- `guests` table holds PII (name + phone). RLS policies will need to be extended to cover `guests` and `guest_visits` in the database migration.
- Waiver documents for guests stored in S3 with Object Lock (Compliance Mode), consistent with member waivers.
- No new Lambda endpoints in this PR — API outline only.

## Testing

Design doc changes only — no implementation code changed.

## Breaking changes

None.
