### PR TITLE
fix: remove staging environment references from infra instructions

### DIFF
--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -114,10 +114,19 @@ Before Route 53 can route to an API Gateway endpoint, a custom domain name must 
 
 ```yaml
 # In api.yaml — one ApiGatewayDomainName resource per region
+
+# prod → api.outdoorsportsclub.com; dev → api.dev.outdoorsportsclub.com
+Mappings:
+  EnvDomain:
+    prod:
+      ApiDomain: api.outdoorsportsclub.com
+    dev:
+      ApiDomain: api.dev.outdoorsportsclub.com
+
 ApiDomainName:
   Type: AWS::ApiGateway::DomainName
   Properties:
-    DomainName: !Sub "api.outdoorsportsclub.${Environment}.example.com"
+    DomainName: !FindInMap [EnvDomain, !Ref Environment, ApiDomain]
     RegionalCertificateArn: !Ref AcmCertArn   # ACM cert in same region
     EndpointConfiguration:
       Types: [REGIONAL]
@@ -159,6 +168,13 @@ Always use **A ALIAS** records (not CNAME) for API Gateway — ALIAS records are
 
 ```yaml
 # In route53.yaml
+Mappings:
+  EnvDomain:
+    prod:
+      ApiDomain: api.outdoorsportsclub.com
+    dev:
+      ApiDomain: api.dev.outdoorsportsclub.com
+
 Parameters:
   HostedZoneId:
     Type: String
@@ -175,7 +191,7 @@ Resources:
     Type: AWS::Route53::RecordSet
     Properties:
       HostedZoneId: !Ref HostedZoneId
-      Name: !Sub "api.outdoorsportsclub.${Environment}.example.com"
+      Name: !FindInMap [EnvDomain, !Ref Environment, ApiDomain]
       Type: A
       AliasTarget:
         DNSName: !Ref ApiGatewayRegionalDomainName


### PR DESCRIPTION
ODQ 28 (resolved in PR #37) established that there is no staging environment — only `dev` and `prod`. This PR removes the four remaining `staging` references from `infra.instructions.md` that were not caught in that PR.

Changes:
- `Environments: prod, staging, dev` → `prod, dev`
- `api.staging.outdoorsportsclub.com` subdomain removed
- `staging.outdoorsportsclub.com` hosted zone removed
- Aurora ACU sizing `dev/staging` → `dev`
- "dev and staging costs" → "dev costs"

The `staging` mention in `docs/design.md` line 1144 is intentionally retained — it is part of the ODQ 28 resolved decision text explaining that no staging tier was added, which is accurate historical record.

Closes no issue — follow-up cleanup from PR #37.
