### PR TITLE
chore: capture infra lessons learned from Phase 1-3 session

### DIFF
--- a/.github/instructions/infra.instructions.md
+++ b/.github/instructions/infra.instructions.md
@@ -206,7 +206,7 @@ Resources:
 * Set `MinCapacity: 0.5` and `MaxCapacity: 4` ACUs for `dev`; `MinCapacity: 1` and `MaxCapacity: 16` for `prod`
 * Enable `EnableHttpEndpoint: true` on the cluster to activate the RDS Data API
 * Reference the Secrets Manager secret ARN in the cluster definition for RDS Data API authentication
-* **Aurora security group egress:** A `0.0.0.0/0` HTTPS egress rule does not by itself restrict traffic to AWS endpoints — it is the absence of a NAT gateway or internet gateway on the private subnets that prevents actual egress. The hardened alternative is to provision **VPC interface endpoints** for `kms` and `secretsmanager` (no egress rule needed at all) — prefer this for production deployments.
+* **Aurora security group egress:** A `0.0.0.0/0` HTTPS egress rule does not by itself restrict traffic to AWS endpoints — it is the absence of a NAT gateway or internet gateway on the private subnets that prevents actual egress. The hardened alternative is to provision **VPC interface endpoints** for `kms` and `secretsmanager` (no `0.0.0.0/0` egress rule needed — replace it with egress scoped to the endpoint's security group, and configure the endpoint SG to allow inbound from the Aurora SG) — prefer this for production deployments.
 * **`aurora.yaml` must only be deployed in the primary region.** Secondary-region Aurora Global Database secondary clusters are provisioned separately. Deploying `aurora.yaml` in a secondary region with `IsMultiRegion: true` would attempt to create a duplicate `GlobalClusterIdentifier` and fail.
 
 ## S3 — Waiver Bucket


### PR DESCRIPTION
Two standing rules added to `infra.instructions.md` based on gaps caught during Phase 1–3 PR reviews. Neither rises to the level of an architectural decision, but both are patterns that caused review comments and should be applied proactively going forward.

## Changes

- **.github/instructions/infra.instructions.md — Secrets Manager section:** Added rule that any secret which cannot be auto-generated must use a `NoEcho` parameter with `MinLength` and `AllowedPattern` constraints. A placeholder value (e.g. `REPLACE_ME`) in `SecretString` is explicitly prohibited. CloudFormation parameter validation is the enforcement mechanism — it rejects the deployment before the placeholder can reach Secrets Manager. Includes a working YAML example for the device-token salt pattern.

- **.github/instructions/infra.instructions.md — Aurora section:** Two new bullets:
  1. Clarifies that a `0.0.0.0/0` HTTPS egress rule on the Aurora security group does **not** restrict traffic to AWS endpoints — the private subnet topology (no IGW or NAT gateway) is what actually prevents egress. Documents VPC interface endpoints for `kms` and `secretsmanager` as the hardened production alternative.
  2. Explicitly states that `aurora.yaml` must only be deployed in the primary region. Secondary-region Global Database secondaries are provisioned separately. Deploying in a secondary region with `IsMultiRegion: true` would attempt to create a duplicate `GlobalClusterIdentifier` and fail.

## Motivation

Both rules were caught by Copilot review comments during Phase 1–3 rather than being applied from the start:
- The `DeviceTokenSalt` placeholder reached PR #41 before the `NoEcho` pattern was applied (comment 2950660107)
- The egress comment overclaimed AWS-only restriction and was corrected in PR #42 (comment 2950708727)
- The primary-region deployment constraint was flagged in PR #42 (comment 2950708713)

Adding them to the instructions means future stacks get these right at authoring time instead of review time.

## Security considerations
- The `NoEcho` pattern is a security hardening rule — it prevents accidental deployment of predictable/placeholder HMAC salts or other manually-supplied secrets
- No infrastructure changes in this PR

## Testing
N/A — documentation only.

## Breaking changes
None.
