### PR TITLE
feat: backup vault and Lambda IAM execution roles

### DIFF
--- a/infra/stacks/backup.yaml
+++ b/infra/stacks/backup.yaml
@@ -20,6 +20,9 @@ Parameters:
     Description: >-
       Ordered list of active regions. First entry is the primary (writer)
       region. Used to determine whether cross-region copy rules are needed.
+      Maximum two entries are supported by this stack — the S3 cross-region
+      copy action targets index 1 only. For three or more active regions,
+      add additional CopyActions entries to S3BackupPlan manually.
       Example: "us-east-1,us-east-2"
 
 Conditions:
@@ -92,21 +95,19 @@ Resources:
           Value: cloudformation
 
   # ---------------------------------------------------------------------------
-  # Backup Plan
+  # Aurora Backup Plan — PITR only.
+  # Aurora Global Database handles cross-region replication natively; a
+  # cross-region Backup copy of Aurora is not needed here.
   # ---------------------------------------------------------------------------
-  BackupPlan:
+  AuroraBackupPlan:
     Type: AWS::Backup::BackupPlan
     Properties:
       BackupPlan:
-        BackupPlanName: !Sub "osc-backup-plan-${Environment}"
+        BackupPlanName: !Sub "osc-aurora-backup-plan-${Environment}"
         BackupPlanRule:
-
-          # Rule 1: Continuous PITR for Aurora — 35-day recovery window.
-          # EnableContinuousBackup activates point-in-time restore on the
-          # Aurora cluster so any second within the retention window can be
-          # targeted. ScheduleExpression is still required by CloudFormation
-          # even when continuous backup is enabled; the daily trigger below
-          # serves as the snapshot anchor alongside PITR.
+          # Continuous PITR — any second within the retention window can be
+          # targeted. ScheduleExpression is required by CloudFormation even
+          # when continuous backup is enabled.
           - RuleName: AuroraPITR
             TargetBackupVault: !Ref BackupVault
             EnableContinuousBackup: true
@@ -115,10 +116,36 @@ Resources:
             CompletionWindowMinutes: 180
             Lifecycle:
               DeleteAfterDays: !If [IsProd, 35, 7]
+      BackupPlanTags:
+        Project: outdoor-sports-club
+        Environment: !Ref Environment
+        ManagedBy: cloudformation
 
-          # Rule 2: Daily snapshot at 02:00 UTC for both Aurora and S3.
-          # Cross-region copy rule fires when IsMultiRegion is true; the
-          # destination region is the second entry in RegionList.
+  AuroraBackupSelection:
+    Type: AWS::Backup::BackupSelection
+    Properties:
+      BackupPlanId: !Ref AuroraBackupPlan
+      BackupSelection:
+        SelectionName: !Sub "osc-aurora-backup-selection-${Environment}"
+        IamRoleArn: !GetAtt BackupServiceRole.Arn
+        Resources:
+          - !ImportValue
+            Fn::Sub: "osc-aurora-cluster-arn-${Environment}"
+
+  # ---------------------------------------------------------------------------
+  # S3 Backup Plan — daily snapshot + cross-region copy for the waivers bucket.
+  # S3 CRR (in s3.yaml) handles object-level replication; this plan provides
+  # a separate recovery point in the AWS Backup vault.
+  # ---------------------------------------------------------------------------
+  S3BackupPlan:
+    Type: AWS::Backup::BackupPlan
+    Properties:
+      BackupPlan:
+        BackupPlanName: !Sub "osc-s3-backup-plan-${Environment}"
+        BackupPlanRule:
+          # Daily snapshot at 02:00 UTC. Cross-region copy fires when
+          # IsMultiRegion is true and targets RegionList index 1 only
+          # (see RegionList parameter description for the 2-region limit).
           - RuleName: DailySnapshot
             TargetBackupVault: !Ref BackupVault
             ScheduleExpression: "cron(0 2 * * ? *)"
@@ -132,27 +159,21 @@ Resources:
                     - "arn:aws:backup:${SecondaryRegion}:${AWS::AccountId}:backup-vault:osc-backup-vault-${Environment}"
                     - SecondaryRegion: !Select [1, !Ref RegionList]
                   Lifecycle:
-                    DeleteAfterDays: 35
+                    DeleteAfterDays: !If [IsProd, 35, 7]
               - !Ref AWS::NoValue
-
       BackupPlanTags:
         Project: outdoor-sports-club
         Environment: !Ref Environment
         ManagedBy: cloudformation
 
-  # ---------------------------------------------------------------------------
-  # Backup Selection — Aurora cluster + S3 waivers bucket
-  # ---------------------------------------------------------------------------
-  BackupSelection:
+  S3BackupSelection:
     Type: AWS::Backup::BackupSelection
     Properties:
-      BackupPlanId: !Ref BackupPlan
+      BackupPlanId: !Ref S3BackupPlan
       BackupSelection:
-        SelectionName: !Sub "osc-backup-selection-${Environment}"
+        SelectionName: !Sub "osc-s3-backup-selection-${Environment}"
         IamRoleArn: !GetAtt BackupServiceRole.Arn
         Resources:
-          - !ImportValue
-            Fn::Sub: "osc-aurora-cluster-arn-${Environment}"
           - !ImportValue
             Fn::Sub: "osc-s3-waivers-arn-${Environment}"
 

--- a/infra/stacks/iam/lambda-admin-roles.yaml
+++ b/infra/stacks/iam/lambda-admin-roles.yaml
@@ -57,6 +57,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-ranges-occupancy-${Environment}:*"
@@ -109,6 +112,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-settings-get-${Environment}:*"
@@ -161,6 +167,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-settings-patch-${Environment}:*"
@@ -213,6 +222,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-lanes-patch-${Environment}:*"
@@ -265,6 +277,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-lanes-create-${Environment}:*"
@@ -323,6 +338,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-lanes-checkout-${Environment}:*"
@@ -385,6 +403,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-members-reset-auth-${Environment}:*"
@@ -437,6 +458,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-members-level-${Environment}:*"
@@ -489,6 +513,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-members-service-hours-${Environment}:*"
@@ -547,6 +574,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-ranges-status-${Environment}:*"
@@ -600,6 +630,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-admin-pairing-code-${Environment}:*"

--- a/infra/stacks/iam/lambda-kiosk-roles.yaml
+++ b/infra/stacks/iam/lambda-kiosk-roles.yaml
@@ -72,6 +72,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-checkin-${Environment}:*"
@@ -130,6 +133,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-checkout-${Environment}:*"
@@ -196,6 +202,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-waiver-${Environment}:*"
@@ -257,6 +266,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-guest-payment-${Environment}:*"
@@ -318,6 +330,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-consumable-purchase-${Environment}:*"
@@ -379,6 +394,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-dues-${Environment}:*"
@@ -432,6 +450,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-range-lanes-${Environment}:*"
@@ -484,6 +505,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-kiosk-waitlist-cancel-${Environment}:*"
@@ -540,6 +564,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-devices-pair-${Environment}:*"

--- a/infra/stacks/iam/lambda-member-roles.yaml
+++ b/infra/stacks/iam/lambda-member-roles.yaml
@@ -69,6 +69,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-member-me-get-${Environment}:*"
@@ -121,6 +124,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-member-badge-${Environment}:*"
@@ -173,6 +179,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-member-me-patch-${Environment}:*"
@@ -235,6 +244,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-member-dues-${Environment}:*"
@@ -304,6 +316,9 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
+                Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+              - Effect: Allow
+                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/osc-stripe-webhook-${Environment}:*"


### PR DESCRIPTION
## Summary
Provisions the AWS Backup vault/plan and all 25 Lambda IAM execution roles (kiosk, member portal, admin).

## Changes
- `infra/stacks/backup.yaml` — Backup vault (`osc-backup-vault-<env>`), Backup service role, and Backup plan with three rules: Aurora PITR (35-day), daily snapshot at 02:00 UTC, and cross-region copy when `IsMultiRegion` is true. Vault Lock in Compliance mode on prod; off on dev (Governance semantics — no lock configured). Targets the Aurora cluster and S3 waivers bucket via `Fn::ImportValue`.
- `infra/stacks/iam/lambda-kiosk-roles.yaml` — Execution roles for all 9 kiosk Lambdas: check-in, check-out, waiver, guest-payment, consumable-purchase, dues, range-lanes, waitlist-cancel, devices-pair. Waiver role adds `s3:PutObject` + S3 KMS permissions; check-out role adds `sns:Publish`; devices-pair role adds device-token-salt secret access; Stripe-dependent roles (guest-payment, consumable-purchase, dues) gate the Stripe secret permission on `StripeSecretArn` parameter (ODQ 29).
- `infra/stacks/iam/lambda-member-roles.yaml` — Execution roles for all 5 member portal Lambdas: member-me-get, member-badge, member-me-patch, member-dues, stripe-webhook. member-dues gates Stripe secret on `StripeSecretArn`; stripe-webhook role is a placeholder with logging-only permissions until ODQ 29 resolves.
- `infra/stacks/iam/lambda-admin-roles.yaml` — Execution roles for all 11 admin Lambdas: ranges-occupancy, settings-get, settings-patch, lanes-patch, lanes-create, lanes-checkout, members-reset-auth, members-level, members-service-hours, ranges-status, pairing-code. reset-auth adds `cognito-idp:AdminUpdateUserAttributes` + `cognito-idp:AdminDeleteUserAttributes` scoped to the User Pool ARN; lanes-checkout and ranges-status add `sns:Publish`.

## Motivation
PR 4a of the staged infrastructure build. All downstream stacks (api.yaml, Lambda function definitions) will reference the role ARN exports from these files.

## Security considerations
- All roles are least-privilege — no `Resource: "*"` on data-plane actions
- Aurora RDS Data API permissions scoped to the specific cluster ARN
- Stripe secret permissions are absent from all roles while `StripeSecretArn` is empty (ODQ 29 hold)
- Cognito IdP permissions on reset-auth are limited to `AdminUpdateUserAttributes` and `AdminDeleteUserAttributes` on the specific User Pool ARN — no admin create/delete/list actions granted
- Backup service role uses AWS-managed policies (`AWSBackupServiceRolePolicyForBackup` + `AWSBackupServiceRolePolicyForRestores`); no custom wildcard grants
- Vault Lock Compliance mode on prod prevents backup deletion

## Testing
- `cfn-lint` exits 0 on all four templates
- Stacks are parameterized and have not been deployed to AWS; deployment will be validated in the dev environment

## Breaking changes
None — new stacks only, no changes to existing resources.
