### PR TITLE
feat: consumable items catalog — server-side price lookup

### DIFF
--- a/db/migrations/0019_create_consumable_items.sql
+++ b/db/migrations/0019_create_consumable_items.sql
@@ -16,3 +16,6 @@ CREATE INDEX IF NOT EXISTS idx_consumable_items_is_active ON consumable_items (i
 
 ALTER TABLE consumable_purchases
     ADD COLUMN IF NOT EXISTS item_id UUID REFERENCES consumable_items(id);
+
+CREATE INDEX IF NOT EXISTS idx_consumable_purchases_item_id
+    ON consumable_purchases (item_id);

--- a/docs/design.md
+++ b/docs/design.md
@@ -740,7 +740,7 @@ Triggered by a QR scan at range exit. Validates an active open `Range-Checkin` e
 POST /v1/kiosk/consumable-purchase
 ```
 
-Records one or more line items to `consumable_purchases`. The kiosk submits `item_id` (a UUID from the `consumable_items` catalog), `quantity`, and `payment_method`. The Lambda looks up `item_name` and `unit_price_cents` from the catalog server-side — the kiosk never supplies a price. The endpoint presents a payment method choice (see *Payment methods* in Section 4): **Cash**, **NFC** (Tap to Pay), or **Card** (paired Stripe Terminal hardware reader). For NFC and Card, payment is processed via **Stripe Terminal SDK** before the record is inserted. `member_id` is optional — omit for anonymous guest purchases.
+Records a single line item to `consumable_purchases`. The kiosk submits `item_id` (a UUID from the `consumable_items` catalog), `quantity`, and `payment_method`. The Lambda looks up `item_name` and `unit_price_cents` from the catalog server-side — the kiosk never supplies a price. The endpoint presents a payment method choice (see *Payment methods* in Section 4): **Cash**, **NFC** (Tap to Pay), or **Card** (paired Stripe Terminal hardware reader). For NFC and Card, payment is processed via **Stripe Terminal SDK** before the record is inserted. `member_id` is optional — omit for anonymous guest purchases.
 
 **Returns:** `200 OK` (Purchase Recorded), `400 Bad Request` (unknown or inactive item), or `402 Payment Required` (Stripe payment failure).
 

--- a/functions/kiosk/consumable-purchase/handler.py
+++ b/functions/kiosk/consumable-purchase/handler.py
@@ -18,6 +18,8 @@ import json
 import logging
 import os
 import time
+import uuid
+from decimal import Decimal
 from typing import Any
 
 import boto3
@@ -59,6 +61,10 @@ def handler(event: dict, context: Any) -> dict:
             raise ValueError(f"payment_method must be one of: {', '.join(_VALID_PAYMENT_METHODS)}")
         if not isinstance(quantity, int) or quantity <= 0:
             raise ValueError("quantity must be a positive integer")
+        try:
+            uuid.UUID(item_id)
+        except (ValueError, AttributeError):
+            raise ValueError("item_id must be a valid UUID")
 
         stripe_intent_id = body.get("stripe_payment_intent_id")
         if payment_method in ("NFC", "Card") and not stripe_intent_id:
@@ -79,9 +85,9 @@ def handler(event: dict, context: Any) -> dict:
         item_name: str = item_result["records"][0][0]["stringValue"]
         unit_price_cents: int = item_result["records"][0][1]["longValue"]
 
-        # Compute total server-side from catalog price — never trust client-supplied amounts
-        unit_price: float = unit_price_cents / 100.0
-        total: float = round(quantity * unit_price, 2)
+        # Use Decimal for exact monetary arithmetic — avoids float rounding drift
+        unit_price: Decimal = Decimal(unit_price_cents) / Decimal(100)
+        total: Decimal = unit_price * quantity
 
         # Verify Stripe payment before opening the write transaction
         if payment_method in ("NFC", "Card"):
@@ -160,8 +166,8 @@ def handler(event: dict, context: Any) -> dict:
                     {"name": "item_id", "value": {"stringValue": item_id}},
                     {"name": "item_name", "value": {"stringValue": item_name}},
                     {"name": "quantity", "value": {"longValue": quantity}},
-                    {"name": "unit_price", "value": {"doubleValue": unit_price}},
-                    {"name": "total", "value": {"doubleValue": total}},
+                    {"name": "unit_price", "value": {"stringValue": str(unit_price)}},
+                    {"name": "total", "value": {"stringValue": str(total)}},
                     {"name": "stripe_intent", "value": (
                         {"stringValue": stripe_intent_id} if stripe_intent_id
                         else {"isNull": True}


### PR DESCRIPTION
## Summary

Introduces a `consumable_items` catalog table so that item names and prices are managed server-side. The kiosk now submits an `item_id` instead of free-text `item_name` + client-supplied `unit_price`; the handler looks up the authoritative price from the catalog before processing payment.

## Changes

- `db/migrations/0019_create_consumable_items.sql` — creates `consumable_items` (id, name, unit_price_cents, is_active) and adds a nullable `item_id` FK to `consumable_purchases` for audit traceability
- `functions/kiosk/consumable-purchase/handler.py` — replaces `item_name`/`unit_price` request fields with `item_id`; adds catalog lookup before Stripe verification; Stripe amount check now uses `unit_price_cents × quantity` directly (no float rounding)
- `docs/design.md` — adds section 5.7a (`consumable_items`), updates `consumable_purchases` column list (`item_id`, denormalized rationale), updates ER diagram, updates endpoint spec

## Motivation

The handler previously accepted `item_name` and `unit_price` from the request body. A client-supplied price is trivially forgeable — a kiosk could submit `unit_price: 0.01` for any item. This change enforces the **Correctness > Convenience** and **Security by Default** engineering values: monetary amounts are never read from the client; they are always looked up server-side from a trusted catalog.

Closes the finding from PR #48 review (comment #2963804736).

## Security considerations

- `unit_price` removed from the request body entirely — the handler raises `400` if the item is not found in `consumable_items` with `is_active = TRUE`
- Stripe amount check now uses `unit_price_cents * quantity` (integer arithmetic) — eliminates the previous `int(round(total * 100))` float conversion that could theoretically drift by one cent
- `consumable_items` is not under RLS (no member PII; access enforced at the API layer via Device Token auth)
- `item_id` FK in `consumable_purchases` is nullable — pre-existing records correctly receive `NULL`

## Testing

- Verified handler logic by code review: item lookup returns `400` for unknown/inactive items; Stripe amount check uses catalog cents value; INSERT includes `item_id`
- Migration is idempotent: `CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`

## Breaking changes

The request body contract for `POST /v1/kiosk/consumable-purchase` changes:

| Before | After |
| :--- | :--- |
| `item_name` (string) | removed |
| `unit_price` (float) | removed |
| — | `item_id` (UUID, required) |

Kiosk frontend must be updated to send `item_id` from the catalog instead of free-text name and price. No DB schema column removals — `item_name` and `unit_price` remain in `consumable_purchases` (populated from the catalog at write time).
