### PR TITLE
docs: add first-deploy and lambda-code-deploy runbooks

### DIFF
--- a/docs/runbooks/first-deploy.md
+++ b/docs/runbooks/first-deploy.md
@@ -11,7 +11,7 @@ This runbook covers deploying the full Outdoor Sports Club infrastructure and La
 ```mermaid
 flowchart TD
     A[Prerequisites:\nAWS profile + permissions] --> B["make gen-salt\n(copy output)"]
-    B --> C["make deploy-base ENV=dev\nDEVICE_TOKEN_SALT=&lt;salt&gt;"]
+    B --> C["make deploy-base ENV=dev\nDEVICE_TOKEN_SALT=<salt>"]
     C --> D{All stacks\nUPDATE_COMPLETE?}
     D -- No --> E[Check CloudFormation\nevents, fix template,\nre-run failed target]
     E --> C
@@ -36,7 +36,7 @@ flowchart TD
 Before running any `make` commands:
 
 * AWS CLI installed and the `outdoorsportsclub` profile configured (`aws configure --profile outdoorsportsclub`)
-* IAM user or role has permissions for: `cloudformation:*`, `lambda:*`, `s3:*`, `secretsmanager:*`, `rds-data:*`, `sts:GetCallerIdentity`
+* IAM user or role has permissions for: `cloudformation:*`, `iam:*`, `kms:*`, `lambda:*`, `s3:*`, `secretsmanager:*`, `rds-data:*`, `sts:GetCallerIdentity` (see [aws-account-setup.md](aws-account-setup.md) — `AdministratorAccess` covers all of these)
 * You are deploying to `us-east-1` (the only supported region for both `dev` and `prod`)
 * The repo is checked out and you are on the `main` branch at the commit you intend to deploy
 
@@ -69,11 +69,11 @@ This deploys stacks in dependency order:
 | 1 | `osc-kms-dev` | `infra/stacks/kms.yaml` |
 | 2 | `osc-secrets-dev` | `infra/stacks/secrets.yaml` |
 | 3 | `osc-sns-dev` | `infra/stacks/sns.yaml` |
-| 3 | `osc-s3-dev` | `infra/stacks/s3.yaml` |
-| 4 | `osc-aurora-dev` | `infra/stacks/aurora.yaml` |
-| 5 | `osc-backup-dev` | `infra/stacks/backup.yaml` |
-| 5 | `osc-iam-kiosk-dev` | `infra/stacks/iam/lambda-kiosk-roles.yaml` |
-| 6 | `osc-artifacts-dev` | `infra/stacks/artifacts.yaml` |
+| 4 | `osc-s3-dev` | `infra/stacks/s3.yaml` |
+| 5 | `osc-aurora-dev` | `infra/stacks/aurora.yaml` |
+| 6 | `osc-backup-dev` | `infra/stacks/backup.yaml` |
+| 7 | `osc-iam-kiosk-dev` | `infra/stacks/iam/lambda-kiosk-roles.yaml` |
+| 8 | `osc-artifacts-dev` | `infra/stacks/artifacts.yaml` |
 
 **Verify:** in the AWS Console → CloudFormation, confirm every stack shows `UPDATE_COMPLETE` or `CREATE_COMPLETE` before proceeding. If any stack fails, check **Events** for the failing resource, fix the template, and re-run the specific target (e.g., `make deploy-aurora ENV=dev`).
 
@@ -119,7 +119,9 @@ Deploys `osc-lambda-dev` from `infra/stacks/lambda.yaml`, which creates all Lamb
 make migrate ENV=dev
 ```
 
-Queries CloudFormation for the Aurora cluster ARN and master secret ARN, then runs `scripts/migrate.py`, which executes all files in `db/migrations/` in filename order via the RDS Data API.
+Queries CloudFormation for the Aurora cluster ARN and the Aurora-managed master secret ARN (exported as `osc-aurora-managed-secret-arn-<env>` from `osc-aurora-<env>`), then runs `scripts/migrate.py`, which executes all files in `db/migrations/` in filename order via the RDS Data API.
+
+> **Known issue (ODQ 32):** The current `make migrate` implementation queries `osc-secrets-<env>` for `AuroraMasterSecretArn` instead of the Aurora-managed secret. If migrations fail with an authentication error on a fresh environment, this is the cause. ODQ 32 tracks the Makefile fix.
 
 **Verify:** `migrate.py` prints each migration filename and `OK` or raises on failure. Confirm all 19 migrations complete without error.
 

--- a/docs/runbooks/lambda-code-deploy.md
+++ b/docs/runbooks/lambda-code-deploy.md
@@ -14,9 +14,11 @@ There are two code deployment paths depending on whether the Lambda CloudFormati
 flowchart TD
     A["Edit handler.py"] --> B["make package ENV=dev\n(zip handlers + _auth.py)"]
     B --> C["make upload ENV=dev\n(s3 cp ZIPs to artifacts bucket)"]
-    C --> D{Did infra/stacks/lambda.yaml\nor IAM templates also change?}
+    C --> D{Did infra/stacks/lambda.yaml\nalso change?}
     D -- Yes --> E["make deploy-lambda ENV=dev\n(CloudFormation deploy)"]
     D -- No --> F["make update-code ENV=dev\n(lambda update-function-code)"]
+    C --> G2{Did an IAM template\nin infra/stacks/iam/ change?}
+    G2 -- Yes --> E2["make deploy-iam-kiosk ENV=dev\n(separate IAM stack)"]
     E --> G["make invoke — smoke test"]
     F --> G
     G --> H[Done]
@@ -48,13 +50,21 @@ Copies each ZIP to `s3://osc-lambda-artifacts-dev-<account-id>/`. This overwrite
 
 ## Step 3 — Push new code to Lambda
 
-### If `infra/stacks/lambda.yaml` (or any IAM template) also changed:
+### If `infra/stacks/lambda.yaml` also changed:
 
 ```bash
 make deploy-lambda ENV=dev
 ```
 
-CloudFormation updates the stack. Lambda picks up the new ZIP from S3 as part of the resource update.
+CloudFormation updates the `osc-lambda-<env>` stack. Lambda picks up the new ZIP from S3 as part of the resource update.
+
+### If an IAM template in `infra/stacks/iam/` also changed:
+
+```bash
+make deploy-iam-kiosk ENV=dev
+```
+
+IAM roles live in a separate stack (`osc-iam-kiosk-<env>`) and are deployed independently. Run this before `deploy-lambda` if the execution role or policies changed.
 
 ### If only handler code changed (no template change):
 


### PR DESCRIPTION
Adds two operational runbooks to `docs/runbooks/` derived from the Makefile, surfaced during the March 20 session retrospective.

## Changes

- **`docs/runbooks/first-deploy.md`** — step-by-step guide for initial environment provisioning: `gen-salt`, `deploy-base` (with stack dependency order table), `package`, `upload`, `deploy-lambda`, `migrate`, and smoke test via `make invoke`. Includes a Mermaid deploy-flow diagram and notes on Aurora provisioning time and migration idempotency.

- **`docs/runbooks/lambda-code-deploy.md`** — covers the two code deployment paths (template change vs. code-only change), explains why `make deploy-lambda` silently does nothing on code-only redeploys (`NO_CHANGES`), and documents the `make update-code` path. Includes a Mermaid decision diagram and a single-handler iteration shortcut for active development.

- **`docs/runbooks/kiosk-provisioning.md`** — verified as-is; already covers the `devices/pair` pairing-code flow end-to-end. No changes needed.

## Motivation

The Makefile quickstart comment is correct but insufficient for a first-time operator and does not explain the `deploy-lambda` vs `update-code` distinction. That distinction has a silent failure mode: re-running `deploy-lambda` on a code-only change succeeds with `No changes to deploy` but leaves stale code running. Both runbooks close that gap.

## Breaking changes

None — documentation only.
