### PR TITLE
chore: add destroy-lambda, destroy-sns, destroy-iam targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ STACK_LAMBDA    = osc-lambda-$(ENV)
         deploy-kms deploy-secrets deploy-sns deploy-s3 deploy-aurora \
         deploy-backup deploy-iam-kiosk deploy-artifacts deploy-lambda \
         deploy-base deploy-all update-code migrate invoke \
-        destroy-lambda destroy-sns destroy-iam
+        _guard-nonprod destroy-lambda destroy-sns destroy-iam-kiosk
 
 # =============================================================================
 help:
@@ -78,7 +78,7 @@ help:
 	@echo "Destroy targets (dev only — blocked on ENV=prod):"
 	@echo "  destroy-lambda    Delete the Lambda + API Gateway stack (rebuildable via deploy-lambda)"
 	@echo "  destroy-sns       Delete the SNS topic stack (rebuildable via deploy-base)"
-	@echo "  destroy-iam       Delete the IAM roles stack (rebuildable via deploy-base)"
+	@echo "  destroy-iam-kiosk Delete the IAM kiosk roles stack (rebuildable via deploy-base)"
 	@echo ""
 	@echo "Variables:"
 	@echo "  ENV=$(ENV)  AWS_PROFILE=$(AWS_PROFILE)  REGION=$(REGION)"
@@ -294,6 +294,9 @@ destroy-lambda: _guard-nonprod
 	@echo "$(STACK_LAMBDA) deleted. Rebuild with: make deploy-lambda ENV=$(ENV)"
 
 destroy-sns: _guard-nonprod
+	@aws cloudformation describe-stacks --stack-name $(STACK_LAMBDA) \
+		--profile $(AWS_PROFILE) --region $(REGION) > /dev/null 2>&1 && \
+		echo "ERROR: $(STACK_LAMBDA) still exists and imports $(STACK_SNS) exports. Run 'make destroy-lambda ENV=$(ENV)' first." && exit 1 || true
 	aws cloudformation delete-stack \
 		--stack-name $(STACK_SNS) \
 		--profile $(AWS_PROFILE) --region $(REGION)
@@ -301,8 +304,10 @@ destroy-sns: _guard-nonprod
 		--stack-name $(STACK_SNS) \
 		--profile $(AWS_PROFILE) --region $(REGION)
 	@echo "$(STACK_SNS) deleted. Rebuild with: make deploy-base ENV=$(ENV)"
-
-destroy-iam: _guard-nonprod
+destroy-iam-kiosk: _guard-nonprod
+	@aws cloudformation describe-stacks --stack-name $(STACK_LAMBDA) \
+		--profile $(AWS_PROFILE) --region $(REGION) > /dev/null 2>&1 && \
+		echo "ERROR: $(STACK_LAMBDA) still exists and imports $(STACK_IAM_KIOSK) exports. Run 'make destroy-lambda ENV=$(ENV)' first." && exit 1 || true
 	aws cloudformation delete-stack \
 		--stack-name $(STACK_IAM_KIOSK) \
 		--profile $(AWS_PROFILE) --region $(REGION)


### PR DESCRIPTION
Adds three stack-destroy targets to the Makefile for stateless, fully rebuildable stacks. All are blocked on `ENV=prod` via a shared `_guard-nonprod` prerequisite.

## Changes

- `destroy-lambda` — deletes `osc-lambda-<env>` (Lambda + API Gateway); rebuild with `make deploy-lambda`
- `destroy-sns` — deletes `osc-sns-<env>` (SNS topic); rebuild with `make deploy-base`
- `destroy-iam` — deletes `osc-iam-kiosk-<env>` (IAM roles); rebuild with `make deploy-base`
- All three added to `.PHONY` and documented in `make help` under a "Destroy targets (dev only)" section
- Stateful stacks with `DeletionPolicy: Retain` (kms, secrets, aurora, s3, cognito, artifacts, backup) are intentionally excluded

## Motivation

Destroying and rebuilding stateless stacks exercises the deployment templates from scratch and catches drift that `cloudformation deploy` with `--no-fail-on-empty-changeset` would silently skip. Useful for verifying IAM templates are self-sufficient and that `deploy-lambda` works cleanly against a fresh function stack.

## Security considerations

None — these are local Makefile targets that invoke `aws cloudformation delete-stack`. The prod guard (`_guard-nonprod`) prevents accidental use against the production environment.

## Breaking changes

None — additive only.
