### PR TITLE
docs: add stack-destroy-rebuild and dev-environment-reset runbooks

### DIFF
--- a/docs/runbooks/dev-environment-reset.md
+++ b/docs/runbooks/dev-environment-reset.md
@@ -14,7 +14,7 @@ broken state, or you want to verify the deployment templates work from scratch.
 ## What this resets
 
 | Stack | Action |
-|---|---|
+| :--- | :--- |
 | `osc-lambda-dev` | Destroyed and redeployed |
 | `osc-iam-kiosk-dev` | Destroyed and redeployed |
 | `osc-sns-dev` | Destroyed and redeployed |
@@ -28,8 +28,8 @@ left intact. No data is lost and no credentials rotate.
 
 ## Prerequisites
 
-- AWS CLI configured with the `outdoorsportsclub` profile (`us-east-1`)
-- Lambda ZIPs are already uploaded to `osc-lambda-artifacts-dev-<account-id>`
+* AWS CLI configured with the `outdoorsportsclub` profile (`us-east-1`)
+* Lambda ZIPs are already uploaded to `osc-lambda-artifacts-dev-<account-id>`
   (if not, run `make package upload ENV=dev` first — see the [Lambda code deploy runbook](lambda-code-deploy.md))
 
 ---
@@ -121,7 +121,7 @@ make invoke ENV=dev FUNCTION=osc-kiosk-range-lanes-dev PAYLOAD='{"httpMethod":"G
 `deploy-base` did not complete successfully or `osc-iam-kiosk-dev` is still deleting.
 Wait for `deploy-base` to finish fully before running `deploy-lambda`.
 
-**`make invoke` returns 502**
+**`make invoke` returns a `FunctionError` or a non-200 `statusCode` in the response body**
 Lambda deployed but the handler is failing at startup. Check CloudWatch Logs:
 ```bash
 aws logs tail /aws/lambda/osc-kiosk-range-lanes-dev --since 5m --profile outdoorsportsclub

--- a/docs/runbooks/stack-destroy-rebuild.md
+++ b/docs/runbooks/stack-destroy-rebuild.md
@@ -17,7 +17,7 @@ or exercise the deployment path from a clean state.
 Only stacks without stateful resources are eligible. The three supported targets are:
 
 | Target | Stack deleted | Rebuild command |
-|---|---|---|
+| :--- | :--- | :--- |
 | `make destroy-lambda` | `osc-lambda-<env>` (Lambda functions + API Gateway) | `make deploy-lambda ENV=<env>` |
 | `make destroy-sns` | `osc-sns-<env>` (SNS topic) | `make deploy-base ENV=<env>` |
 | `make destroy-iam-kiosk` | `osc-iam-kiosk-<env>` (IAM roles + policies) | `make deploy-base ENV=<env>` |
@@ -25,21 +25,21 @@ Only stacks without stateful resources are eligible. The three supported targets
 **Do not attempt to destroy** the following — they carry `DeletionPolicy: Retain`
 and cannot be cleanly cycled without manual cleanup:
 
-- `osc-kms-<env>` — KMS key deletion has a 7–30 day waiting period; existing ciphertext breaks
-- `osc-secrets-<env>` — holds the device token salt and DB credentials referenced by Lambda
-- `osc-aurora-<env>` — dataset; slow to reprovision
-- `osc-s3-<env>` — waiver documents
-- `osc-cognito-<env>` — pool IDs are baked into Amplify config and kiosk device configs
-- `osc-artifacts-<env>` — Lambda deployment packages
-- `osc-backup-<env>` — AWS Backup vault
+* `osc-kms-<env>` — KMS key deletion has a 7–30 day waiting period; existing ciphertext breaks
+* `osc-secrets-<env>` — holds the device token salt and DB credentials referenced by Lambda
+* `osc-aurora-<env>` — dataset; slow to reprovision
+* `osc-s3-<env>` — waiver documents
+* `osc-cognito-<env>` — pool IDs are baked into Amplify config and kiosk device configs
+* `osc-artifacts-<env>` — Lambda deployment packages
+* `osc-backup-<env>` — AWS Backup vault
 
 ---
 
 ## Prerequisites
 
-- AWS CLI configured with the `outdoorsportsclub` profile (`us-east-1`)
-- `ENV` set to `dev` (or a non-prod environment)
-- The stacks to be destroyed exist (`aws cloudformation list-stacks` to verify)
+* AWS CLI configured with the `outdoorsportsclub` profile (`us-east-1`)
+* `ENV` set to `dev` (destroy targets must never run with `ENV=prod`)
+* The stacks to be destroyed exist (`aws cloudformation list-stacks` to verify)
 
 ---
 
@@ -120,8 +120,10 @@ make invoke ENV=dev \
   PAYLOAD='{"headers":{"x-device-token":"<token>"},"httpMethod":"GET","path":"/v1/kiosk/range/lanes"}'
 ```
 
-Expected: HTTP 200 with a JSON body. A 401 or 403 indicates the IAM role or
-Cognito Authorizer is not configured correctly.
+Expected: HTTP 200 with a JSON body. A 401 or 403 indicates the kiosk device
+token is missing or invalid and the handler's device-token authorization logic
+is rejecting the request; IAM permission issues typically surface as a
+`FunctionError` or an unhandled exception in the invocation response.
 
 ---
 


### PR DESCRIPTION
Adds two operational runbooks for the `destroy-*` Makefile targets introduced in PR #59.

## Changes

- `docs/runbooks/stack-destroy-rebuild.md` — reference runbook for individual destroy targets. Covers which stacks are eligible (and why others are excluded), the CloudFormation cross-stack dependency that dictates destroy/rebuild order, per-target commands, and a troubleshooting section.
- `docs/runbooks/dev-environment-reset.md` — end-to-end procedure for resetting all rebuildable stacks in `dev` to a clean state. Covers the full sequence (destroy → deploy-base → deploy-lambda → migrate → smoke test), a "full sequence at a glance" block, and troubleshooting for the common failure modes.

**Note:** The Makefile changes (`destroy-*` targets, `.PHONY`, help text) landed in PR #59 and are not part of this PR.

## Motivation

PR #59 added the destroy targets but left the dependency ordering and correct sequence implicit. Without a runbook, an operator who runs `destroy-iam-kiosk` before `destroy-lambda` hits a `DELETE_FAILED` error with no guidance. These runbooks make the correct sequence explicit and document why it matters.

## Breaking changes

None — documentation only.
