### PR TITLE
fix: make migrate queries AuroraManagedSecretArn from osc-aurora stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,8 +247,8 @@ migrate:
 		--query "Stacks[0].Outputs[?OutputKey=='AuroraClusterArn'].OutputValue" \
 		--output text --profile $(AWS_PROFILE) --region $(REGION)))
 	$(eval SECRET_ARN := $(shell aws cloudformation describe-stacks \
-		--stack-name $(STACK_SECRETS) \
-		--query "Stacks[0].Outputs[?OutputKey=='AuroraMasterSecretArn'].OutputValue" \
+		--stack-name $(STACK_AURORA) \
+		--query "Stacks[0].Outputs[?OutputKey=='AuroraManagedSecretArn'].OutputValue" \
 		--output text --profile $(AWS_PROFILE) --region $(REGION)))
 	CLUSTER_ARN="$(CLUSTER_ARN)" \
 	SECRET_ARN="$(SECRET_ARN)" \

--- a/docs/runbooks/first-deploy.md
+++ b/docs/runbooks/first-deploy.md
@@ -119,9 +119,7 @@ Deploys `osc-lambda-dev` from `infra/stacks/lambda.yaml`, which creates all Lamb
 make migrate ENV=dev
 ```
 
-Queries CloudFormation for the Aurora cluster ARN and the Aurora-managed master secret ARN (exported as `osc-aurora-managed-secret-arn-<env>` from `osc-aurora-<env>`), then runs `scripts/migrate.py`, which executes all files in `db/migrations/` in filename order via the RDS Data API.
-
-> **Known issue (ODQ 32):** The current `make migrate` implementation queries `osc-secrets-<env>` for `AuroraMasterSecretArn` instead of the Aurora-managed secret. If migrations fail with an authentication error on a fresh environment, this is the cause. ODQ 32 tracks the Makefile fix.
+Queries `osc-aurora-<env>` for the cluster ARN (`AuroraClusterArn`) and the Aurora-managed master secret ARN (`AuroraManagedSecretArn`), then runs `scripts/migrate.py`, which executes all files in `db/migrations/` in filename order via the RDS Data API.
 
 **Verify:** `migrate.py` prints each migration filename and `OK` or raises on failure. Confirm all 19 migrations complete without error.
 


### PR DESCRIPTION
`make migrate` was querying `osc-secrets-<env>` for `AuroraMasterSecretArn` — a manual secret that was orphaned when PR #55 migrated Aurora to `ManageMasterUserPassword: true`. Aurora now manages its own credentials and exports them as `AuroraManagedSecretArn` from the `osc-aurora-<env>` stack. The old query would return an empty string, causing `migrate.py` to fail with an authentication error on every fresh environment.

## Changes

- `Makefile` — `migrate` target: query `STACK_AURORA` for `AuroraManagedSecretArn` instead of `STACK_SECRETS` for `AuroraMasterSecretArn`
- `docs/runbooks/first-deploy.md` — Step 6: removed "Known issue (ODQ 32)" caution note; updated description to match the now-correct implementation

## Motivation

ODQ 32 follow-up (the IAM `sns:DestinationType` fix was PR #61). This is the second part of ODQ 32: the `make migrate` implementation was documented as broken in `first-deploy.md` Step 6 pending this fix.

## Security considerations

No change to the secret itself. Both `AuroraMasterSecretArn` (old) and `AuroraManagedSecretArn` (new) are Secrets Manager ARNs for Aurora credentials. The Lambda IAM roles already import `osc-aurora-managed-secret-arn-<env>` from the Aurora stack — this aligns the Makefile with the same source of truth.

## Testing

`make migrate ENV=dev` will now resolve a non-empty `SECRET_ARN` from the Aurora stack and authenticate successfully. Full verification requires a running `dev` cluster.

## Breaking changes

None — this unblocks `make migrate` on fresh environments. Any environment where migrations previously ran (and somehow succeeded despite the wrong secret) would have required a manual workaround that is now unnecessary.
