### PR TITLE
fix: correct missing separator in make help echo lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ help:
 	@echo "Destroy targets (dev only — blocked on ENV=prod):"
 	@echo "  destroy-lambda    Delete the Lambda + API Gateway stack (rebuildable via deploy-lambda)"
 	@echo "  destroy-sns       Delete the SNS topic stack (rebuildable via deploy-base)"
-	@echo "  destroy-iam-kiosk   Delete the IAM kiosk roles stack (rebuildable via deploy-base)
-  destroy-iam-admin   Delete the IAM admin roles stack (rebuildable via deploy-base)
-  destroy-iam-member  Delete the IAM member roles stack (rebuildable via deploy-base)"
+	@echo "  destroy-iam-kiosk   Delete the IAM kiosk roles stack (rebuildable via deploy-base)"
+	@echo "  destroy-iam-admin   Delete the IAM admin roles stack (rebuildable via deploy-base)"
+	@echo "  destroy-iam-member  Delete the IAM member roles stack (rebuildable via deploy-base)"
 	@echo ""
 	@echo "Variables:"
 	@echo "  ENV=$(ENV)  AWS_PROFILE=$(AWS_PROFILE)  REGION=$(REGION)"


### PR DESCRIPTION
Three `destroy-iam-*` echo lines in the `help` target were collapsed into a single `@echo` string with bare-space line continuations. Make requires a tab at the start of every recipe line, so `make help` errored with `missing separator` at line 84. Split them into three separate tab-prefixed `@echo` statements.
