### PR TITLE
fix: restore MasterUserSecret.KmsKeyId to aurora.yaml

### DIFF
--- a/infra/stacks/aurora.yaml
+++ b/infra/stacks/aurora.yaml
@@ -243,14 +243,16 @@ Resources:
       # secret, stores the password there, and rotates it automatically. The managed
       # secret ARN is exported as osc-aurora-managed-secret-arn-<env> for use by
       # Lambda execution roles and the lambda.yaml stack.
-      # Note: When ManageMasterUserPassword is enabled and MasterUserSecret.KmsKeyId
-      # is omitted, Aurora creates the managed secret encrypted with the default
-      # AWS-managed Secrets Manager KMS key for NEW clusters. If a cluster was
-      # originally created with a customer-managed KMS key via MasterUserSecret.KmsKeyId,
-      # that key choice is immutable — ModifyDBCluster cannot change the KMS key on
-      # the existing managed secret. CMK encryption for the managed secret remains a
-      # future consideration for any fresh cluster provisioning.
+      # MasterUserSecret.KmsKeyId can only be applied at cluster CREATION time.
+      # ModifyDBCluster cannot change the KMS key on an existing managed secret.
+      # Any cluster deployed from this template will have its managed secret
+      # encrypted with the project CMK from the start. An existing cluster whose
+      # managed secret was created without this property must be deleted and
+      # recreated — CloudFormation will reject an in-place update attempt.
       ManageMasterUserPassword: true
+      MasterUserSecret:
+        KmsKeyId: !ImportValue
+          Fn::Sub: "osc-kms-aurora-arn-${Environment}"
       StorageEncrypted: true
       KmsKeyId: !ImportValue
         Fn::Sub: "osc-kms-aurora-arn-${Environment}"


### PR DESCRIPTION
## Summary

Restore `MasterUserSecret.KmsKeyId` to `infra/stacks/aurora.yaml` so the Aurora managed secret is encrypted with the project CMK on any fresh cluster provisioning.

## Changes

- **`infra/stacks/aurora.yaml`**: Re-adds `MasterUserSecret.KmsKeyId` pointing to `osc-kms-aurora-arn-${Environment}`. Updates the comment to document the AWS immutability constraint and the required cluster-recreate path (removing the incorrect "future consideration" framing).

## Motivation

PR #70 removed `MasterUserSecret.KmsKeyId` to unblock `make deploy-base ENV=dev` after `ModifyDBCluster` rejected an in-place KMS key change on the existing dev cluster. That fixed the deploy blocker but left the dev cluster's managed secret encrypted with `aws/secretsmanager` (AWS-managed key) instead of the project CMK — a security gap inconsistent with the project's CMK-everywhere posture. Closes the gap introduced by PR #70. Related to #70.

## Security considerations

- Restores CMK encryption for the Aurora managed secret (Secrets Manager secret holding the DB master password) on all fresh cluster provisioning.
- `MasterUserSecret.KmsKeyId` is immutable after cluster creation — this change has no effect on the currently running `osc-aurora-dev` cluster. The dev cluster must be manually deleted and recreated for CMK to take effect there. Prod will get CMK automatically on first provisioning.
- No IAM changes. No new permissions. No new endpoints.

## Testing

cfn-lint reports no errors:

```
find infra -name "*.yaml" | xargs cfn-lint
# (no output — clean)
```

This PR contains no Lambda handler or test file changes — pytest run not required.

## Breaking changes

After this PR merges, running `make deploy-base ENV=dev` against the **existing** `osc-aurora-dev` cluster will fail — CloudFormation will attempt `ModifyDBCluster` and AWS will reject the KMS key change. The cluster must be deleted and recreated first (see cluster recreation steps in PR #70 discussion). Prod is unaffected — no prod cluster exists yet.
