### PR TITLE
chore: suppress Makefile extension configure-on-open prompt

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,6 @@
     "!Sub mapping",
     "!Transform mapping",
     "!Condition scalar"
-  ]
+  ],
+  "makefile.configureOnOpen": false
 }


### PR DESCRIPTION
Adds `"makefile.configureOnOpen": false` to `.vscode/settings.json` to suppress the VS Code Makefile extension's configure-on-open prompt. This setting was written automatically by the extension when the workspace was opened and was confirmed intentional.

No breaking changes.
