### PR TITLE
chore: add commit discipline section to pr.instructions.md

### DIFF
--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -57,7 +57,7 @@ feat: implement Phase 2 API Gateway and dashboard  ← one giant commit with 5 f
 
 This makes `git bisect`, `git revert`, and code review harder, and erases the story of how the solution was reached.
 
-
+## Undoing mistakes — avoid destructive operations
 
 `git reset --hard` rewrites history and discards uncommitted work permanently. In a shared project it can discard in-progress commits others depend on. Prefer reversible alternatives:
 


### PR DESCRIPTION
Adds a **Commit discipline** section to `pr.instructions.md` between Branch rules and Undoing mistakes.

The section codifies the rule enforced during PR #89: one logical change per commit, multiple commits per PR, commit history tells the story. Includes message format, scoped examples, and the anti-pattern to avoid.

`pr.instructions.md` has `applyTo: "**"` so every agent (backend, infra, designer, docs, qa, etc.) reads it on every file they touch.
