### PR TITLE
test(members): expand member/me handler coverage to 11 tests

### DIFF
--- a/tests/unit/test_member_me.py
+++ b/tests/unit/test_member_me.py
@@ -93,3 +93,91 @@ class TestMemberMe:
             resp = mod.handler(member_jwt_event(), FakeContext())
 
         assert "Access-Control-Allow-Origin" in resp["headers"]
+
+    def test_db_error_returns_500(self, mod):
+        rds = MagicMock()
+        rds.begin_transaction.return_value = {"transactionId": "tx-1"}
+        rds.execute_statement.side_effect = RuntimeError("DB connection lost")
+        rds.rollback_transaction.return_value = {}
+        with patch.object(mod, "authenticate_member", return_value=_MEMBER), \
+             patch("boto3.client", return_value=rds):
+            resp = mod.handler(member_jwt_event(), FakeContext())
+
+        assert resp["statusCode"] == 500
+
+    def test_db_error_triggers_rollback(self, mod):
+        rds = MagicMock()
+        rds.begin_transaction.return_value = {"transactionId": "tx-1"}
+        rds.execute_statement.side_effect = RuntimeError("DB connection lost")
+        rds.rollback_transaction.return_value = {}
+        with patch.object(mod, "authenticate_member", return_value=_MEMBER), \
+             patch("boto3.client", return_value=rds):
+            mod.handler(member_jwt_event(), FakeContext())
+
+        rds.rollback_transaction.assert_called_once()
+
+    def test_training_level_from_aurora_not_jwt(self, mod):
+        # JWT/auth says level 1; Aurora row says level 5.
+        # Body must reflect the Aurora-queried value (correctness invariant:
+        # training_level is always re-queried from Aurora, never taken from JWT).
+        member_level_1 = {"member_id": FAKE_MEMBER_ID, "sub": FAKE_SUB, "training_level": 1}
+        row = full_member_profile_row(training_level=5)
+        rds = make_member_rds({
+            "members WHERE id": {"records": [row]},
+            "club_settings": {"records": [[{"longValue": 10000}]]},
+        })
+        with patch.object(mod, "authenticate_member", return_value=member_level_1), \
+             patch("boto3.client", return_value=rds):
+            resp = mod.handler(member_jwt_event(), FakeContext())
+
+        assert resp["statusCode"] == 200
+        body = json.loads(resp["body"])
+        assert body["training_level"] == 5  # Aurora value, not JWT value (1)
+
+    def test_service_hours_double_value(self, mod):
+        # Aurora may return service_hours as NUMERIC → doubleValue; handler must handle both.
+        row = full_member_profile_row()
+        row[2] = {"doubleValue": 2.5}
+        rds = make_member_rds({
+            "members WHERE id": {"records": [row]},
+            "club_settings": {"records": [[{"longValue": 10000}]]},
+        })
+        with patch.object(mod, "authenticate_member", return_value=_MEMBER), \
+             patch("boto3.client", return_value=rds):
+            resp = mod.handler(member_jwt_event(), FakeContext())
+
+        assert resp["statusCode"] == 200
+        body = json.loads(resp["body"])
+        assert body["service_hours"] == "2.5"
+
+    def test_annual_dues_cents_none_when_club_settings_empty(self, mod):
+        rds = make_member_rds({
+            "members WHERE id": {"records": [full_member_profile_row()]},
+            "club_settings": {"records": []},
+        })
+        with patch.object(mod, "authenticate_member", return_value=_MEMBER), \
+             patch("boto3.client", return_value=rds):
+            resp = mod.handler(member_jwt_event(), FakeContext())
+
+        assert resp["statusCode"] == 200
+        body = json.loads(resp["body"])
+        assert body["annual_dues_cents"] is None
+
+    def test_rls_gucs_set_with_correct_member_id_and_training_level(self, mod):
+        # Both RLS GUCs must be set before querying members to ensure the DB
+        # enforces row-level security with the correct identity.
+        rds = make_member_rds({
+            "members WHERE id": {"records": [full_member_profile_row()]},
+            "club_settings": {"records": [[{"longValue": 10000}]]},
+        })
+        with patch.object(mod, "authenticate_member", return_value=_MEMBER), \
+             patch("boto3.client", return_value=rds):
+            mod.handler(member_jwt_event(), FakeContext())
+
+        calls = rds.execute_statement.call_args_list
+        mid_call = next(c for c in calls if "current_member_id" in c.kwargs.get("sql", ""))
+        level_call = next(c for c in calls if "current_training_level" in c.kwargs.get("sql", ""))
+        params_mid = {p["name"]: p["value"] for p in mid_call.kwargs["parameters"]}
+        params_level = {p["name"]: p["value"] for p in level_call.kwargs["parameters"]}
+        assert params_mid["mid"]["stringValue"] == FAKE_MEMBER_ID
+        assert params_level["level"]["stringValue"] == str(_MEMBER["training_level"])


### PR DESCRIPTION
## Summary

Expands `tests/unit/test_member_me.py` from 5 to 11 tests, covering all previously untested code paths in `functions/members/me/handler.py`.

## Changes

- `tests/unit/test_member_me.py` — 6 new test methods added to `TestMemberMe`

## Motivation

Milestone 5 of the proof-of-concept roadmap. The handler was implemented and deployed (commit `4b7ec60`) but test coverage was incomplete. Closes todo.md item 13.

## New tests

| Test | What it covers |
| :--- | :--- |
| `test_db_error_returns_500` | Non-PermissionError raised inside transaction -> 500 response |
| `test_db_error_triggers_rollback` | `rollback_transaction` is called when a DB error occurs |
| `test_training_level_from_aurora_not_jwt` | Body uses Aurora re-queried `training_level`, not the JWT claim value |
| `test_service_hours_double_value` | `service_hours` column returned as `doubleValue` (NUMERIC type) is serialized correctly |
| `test_annual_dues_cents_none_when_club_settings_empty` | `annual_dues_cents` is `None` when `club_settings` has no rows |
| `test_rls_gucs_set_with_correct_member_id_and_training_level` | Both RLS GUC `set_config` calls receive the correct parameter values |

## Security considerations

No handler code changed. The `test_training_level_from_aurora_not_jwt` test directly asserts the correctness invariant from `values.instructions.md`: `training_level` in the response must always come from Aurora, never from the JWT claim.

## Testing

`177 passed in 0.32s`

## Breaking changes

None.
