### PR TITLE
chore(build): remove standalone output mode for Amplify SSR hosting

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const nextConfig: NextConfig = {
-  output: "standalone",
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
Remove `output: "standalone"` from `next.config.ts`.

Amplify Gen 2 has its own Lambda-based SSR compute layer for Next.js and manages server-side rendering itself. The `standalone` output mode is intended for self-hosted Docker/Node deployments and conflicts with Amplify's hosting infrastructure.

No functional change to the app — only affects how the build output is structured.
