### PR TITLE
chore(build): add amplify.yml to use npm install and skip empty backend phase

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,17 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm install
+    build:
+      commands:
+        - npm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+      - .next/cache/**/*


### PR DESCRIPTION
Add `amplify.yml` to the repo root to override Amplify's auto-generated build spec.

**Problem:** The auto-generated spec uses `npm ci`, which requires a `package-lock.json`. The project has no lockfile committed and npm is not installed locally.

**Fix:**
- Use `npm install` instead of `npm ci` (no lockfile required)
- Drop the backend phase entirely — `amplify/backend.ts` exports an empty `defineBackend({})` stub; all backend infra is CloudFormation-managed. Running `npx ampx pipeline-deploy` would be a no-op and adds unnecessary build time.

No functional change to the app or infrastructure.
