### PR TITLE
chore(build): rename next.config.ts to next.config.mjs for Amplify compatibility

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {};
-
-export default nextConfig;


### PR DESCRIPTION
Amplify's build environment does not support `next.config.ts`. The build failed with:

> `Error: Configuring Next.js via 'next.config.ts' is not supported. Please replace the file with 'next.config.js' or 'next.config.mjs'.`

Renames `next.config.ts` → `next.config.mjs` and converts the TypeScript type annotation to a JSDoc comment. The config itself is unchanged (empty object).
