### PR TITLE
fix(auth): replace signIn_failure with signInWithRedirect_failure for Amplify v6

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -18,7 +18,7 @@ export default function AuthCallbackPage() {
       if (payload.event === "signedIn") {
         unsubscribe();
         router.replace("/portal/dashboard");
-      } else if (payload.event === "signIn_failure") {
+      } else if (payload.event === "signInWithRedirect_failure") {
         unsubscribe();
         console.error("OAuth sign-in failed", payload.data);
         setError("Sign-in failed. Please try again.");


### PR DESCRIPTION
Fix TypeScript type error in the OAuth callback page that was blocking the Amplify build.

`signIn_failure` is not a valid Hub event in `aws-amplify` v6. The correct event name for a failed `signInWithRedirect` (social OAuth) flow is `signInWithRedirect_failure`, which is listed in the v6 Hub auth channel type union.

Closes build failure on `https://main.d2rljf3gefhatr.amplifyapp.com`.
