### PR TITLE
fix(dashboard): use static property access for NEXT_PUBLIC_* env vars

### DIFF
--- a/src/components/ConfigureAmplify.tsx
+++ b/src/components/ConfigureAmplify.tsx
@@ -2,8 +2,20 @@
 
 import { Amplify } from "aws-amplify";
 
-function getRequiredEnv(name: string): string {
-  const value = process.env[name];
+// Next.js only statically inlines process.env.NEXT_PUBLIC_* when the property
+// name is a literal at the call site. Dynamic access (process.env[name]) is
+// never replaced in the client bundle — the values are undefined at runtime
+// even though they were set at build time. All NEXT_PUBLIC_* reads must use
+// static literal property access so the bundler can substitute the values.
+const ENV = {
+  userPoolId: process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID,
+  userPoolClientId: process.env.NEXT_PUBLIC_COGNITO_APP_CLIENT_ID,
+  domain: process.env.NEXT_PUBLIC_COGNITO_DOMAIN,
+  redirectSignIn: process.env.NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_IN,
+  redirectSignOut: process.env.NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_OUT,
+};
+
+function requireEnv(value: string | undefined, name: string): string {
   if (!value) {
     throw new Error(
       `Missing required environment variable "${name}" for Amplify Auth configuration.`,
@@ -12,8 +24,7 @@ function getRequiredEnv(name: string): string {
   return value;
 }
 
-function getRedirectUrl(envName: string, fallbackPath: string): string {
-  const value = process.env[envName];
+function resolveRedirect(value: string | undefined, fallbackPath: string, name: string): string {
   if (value) {
     return value;
   }
@@ -21,7 +32,7 @@ function getRedirectUrl(envName: string, fallbackPath: string): string {
     return `${window.location.origin}${fallbackPath}`;
   }
   throw new Error(
-    `Missing environment variable "${envName}" and unable to compute redirect URL during SSR.`,
+    `Missing environment variable "${name}" and unable to compute redirect URL during SSR.`,
   );
 }
 
@@ -31,20 +42,17 @@ Amplify.configure(
   {
     Auth: {
       Cognito: {
-        userPoolId: getRequiredEnv("NEXT_PUBLIC_COGNITO_USER_POOL_ID"),
-        userPoolClientId: getRequiredEnv("NEXT_PUBLIC_COGNITO_APP_CLIENT_ID"),
+        userPoolId: requireEnv(ENV.userPoolId, "NEXT_PUBLIC_COGNITO_USER_POOL_ID"),
+        userPoolClientId: requireEnv(ENV.userPoolClientId, "NEXT_PUBLIC_COGNITO_APP_CLIENT_ID"),
         loginWith: {
           oauth: {
-            domain: getRequiredEnv("NEXT_PUBLIC_COGNITO_DOMAIN"),
+            domain: requireEnv(ENV.domain, "NEXT_PUBLIC_COGNITO_DOMAIN"),
             scopes: ["email", "openid", "profile"],
             redirectSignIn: [
-              getRedirectUrl(
-                "NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_IN",
-                "/auth/callback",
-              ),
+              resolveRedirect(ENV.redirectSignIn, "/auth/callback", "NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_IN"),
             ],
             redirectSignOut: [
-              getRedirectUrl("NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_OUT", "/"),
+              resolveRedirect(ENV.redirectSignOut, "/", "NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_OUT"),
             ],
             responseType: "code",
           },


### PR DESCRIPTION
## Summary

Fix a client-side crash (`Application error`) on the Amplify-hosted site caused by `NEXT_PUBLIC_*` environment variables being `undefined` in the browser bundle.

## Changes

- `src/components/ConfigureAmplify.tsx` — Replace dynamic `process.env[name]` access with a static `ENV` object using literal property access (`process.env.NEXT_PUBLIC_COGNITO_USER_POOL_ID`, etc.). Refactor the two helper functions to accept the already-resolved value instead of re-reading via dynamic key.

## Motivation

Next.js only statically inlines `NEXT_PUBLIC_*` environment variables when the property name is a **literal** at the call site. Dynamic access (`process.env[name]` where `name` is a variable) is never replaced by the bundler — the value is `undefined` in the client-side JS bundle even though the env var is set correctly in Amplify at build time.

The symptom: SSR rendered the HTML correctly (the server has `process.env` at runtime), so `curl` returned 200 and the HTML looked fine. But the moment the client-side React bundle hydrated, it threw `Missing required environment variable "NEXT_PUBLIC_COGNITO_USER_POOL_ID"` — causing the "quick flash, then Application error" seen in Chrome and Safari.

## Security considerations

No changes to auth logic, secrets handling, or IAM. This is a bundler inlining fix only.

## Testing

No `tests/**/*.py` files modified; pytest not required.
After merge, Amplify will rebuild `main` — build should succeed and the site should load without the Application error.

## Breaking changes

None.
