### PR TITLE
fix: derive Amplify app origin at runtime for auth routes

### DIFF
--- a/src/lib/amplifyServerUtils.ts
+++ b/src/lib/amplifyServerUtils.ts
@@ -3,7 +3,26 @@ import { getServerAmplifyConfig } from "@/config/amplifyAuth";
 
 type ServerRunner = ReturnType<typeof createServerRunner>;
 
+function ensureAmplifyAppOrigin(): void {
+  if (process.env.AMPLIFY_APP_ORIGIN) {
+    return;
+  }
+
+  const redirectSignIn = process.env.NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_IN;
+  if (!redirectSignIn) {
+    return;
+  }
+
+  try {
+    process.env.AMPLIFY_APP_ORIGIN = new URL(redirectSignIn).origin;
+  } catch {
+    // Keep existing behavior when redirectSignIn is invalid.
+  }
+}
+
 function getServerRunner(): ServerRunner | null {
+  ensureAmplifyAppOrigin();
+
   const config = getServerAmplifyConfig();
   if (!config) {
     return null;


### PR DESCRIPTION
## Summary
Add a runtime fallback for `AMPLIFY_APP_ORIGIN` in server auth runner setup.

## Changes
- `src/lib/amplifyServerUtils.ts`
  - Added `ensureAmplifyAppOrigin()`.
  - If `AMPLIFY_APP_ORIGIN` is missing, derive it from `NEXT_PUBLIC_COGNITO_REDIRECT_SIGN_IN`.
  - Call the fallback before creating `createServerRunner`.

## Motivation
Hosted `/api/auth/sign-in` is returning 500 with `AmplifyServerContextError: Could not find the AMPLIFY_APP_ORIGIN environment variable` in Amplify runtime logs, even after setting app/branch env vars via CLI.

## Testing
- Local build passed: `npm run build`.
- Runtime logs currently show missing `AMPLIFY_APP_ORIGIN` error on main; this patch is intended to remove that dependency at runtime by deriving origin from redirect URL.

## Breaking changes
None
