### PR TITLE
docs: reconcile kiosk rollout scope and review workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Use plain, professional text in prompts, generated content, review replies, and documentation updates.
+
+Emojis are not allowed in prompts, generated content, review replies, or documentation updates.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -69,7 +69,7 @@ Section 11 is split into two subsections:
 Rules:
 * New ODQ items must be added to the **Unresolved** table with an appropriate Priority.
 * When an item is resolved, remove it from the Unresolved table and add it to the Resolved table, replacing the `Question` content with a concise summary of the decision and a cross-reference to the relevant section (e.g., `See Section 7.1`).
-* Do not mark items as ✅ in-place — move them; do not leave resolved items in the Unresolved table.
+* Do not mark items as resolved in-place; move them. Do not leave resolved items in the Unresolved table.
 * ODQ numbers are not reused. The next new item takes the next sequential number regardless of gaps.
 * **To find the highest ODQ number, read the table rows in Section 11 directly** — do not grep for inline prose references like `see ODQ #N`. Inline references are scattered throughout the document and will not reflect all assigned numbers. The tables are the authoritative source.
 * **Before writing an ODQ that references existing code behavior** (notification path, error handling, resource state, IAM condition values), verify the claim against the actual source file. Security review findings and PR comments are triggers to investigate — not sources of truth. An inaccurate ODQ is harder to act on than no ODQ at all.

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -143,13 +143,13 @@ After opening a PR, run the review workflow to process Copilot reviewer comments
 
 This workflow fetches all inline and PR-level comments, classifies them (Valid / Rejected / Ambiguous), applies fixes, commits, replies, and resolves threads. Run it whenever `copilot-pull-request-reviewer` has posted comments.
 
-Copilot reviewer suggestions are the default path. Prefer accepting and implementing them unless one of these is true:
+Copilot reviewer suggestions are the default path, but accept and implement them only after validating that the underlying claim is correct, within the PR scope, and aligned with documented project decisions and conventions. Prefer accepting them once that validation is complete unless one of these is true:
 
 - The suggestion conflicts with real application operations, runtime behavior, or deployment constraints
 - The suggestion degrades user experience for the intended flow
 - The suggestion introduces a concrete security weakness or vulnerability
 
-If a suggestion is rejected, reply with the specific evidence (file path plus section or behavior) that justifies the rejection.
+If a suggestion is rejected because the claim is unsupported, out of scope, misaligned with documented decisions and conventions, or otherwise conflicts with the criteria above, reply with the specific evidence (file path plus section or behavior) that justifies the rejection.
 
 Use plain, professional language in PR descriptions, review replies, and workflow output. Do not use emojis.
 

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -151,6 +151,8 @@ Copilot reviewer suggestions are the default path. Prefer accepting and implemen
 
 If a suggestion is rejected, reply with the specific evidence (file path plus section or behavior) that justifies the rejection.
 
+Use plain, professional language in PR descriptions, review replies, and workflow output. Do not use emojis.
+
 ## QA — invoke the qa agent after handler PRs
 
 After any PR that adds or modifies a Lambda handler in `functions/`, invoke the qa agent:

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -141,7 +141,7 @@ After opening a PR, run the review workflow to process Copilot reviewer comments
 
 > Run `.github/prompts/review.prompt.md` on PR #N
 
-This workflow fetches all inline and PR-level comments, classifies them (Valid / Invalid / Speculative), applies fixes, commits, replies, and resolves threads. Run it whenever `copilot-pull-request-reviewer` has posted comments.
+This workflow fetches all inline and PR-level comments, classifies them (Valid / Rejected / Ambiguous), applies fixes, commits, replies, and resolves threads. Run it whenever `copilot-pull-request-reviewer` has posted comments.
 
 Copilot reviewer suggestions are the default path. Prefer accepting and implementing them unless one of these is true:
 

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -143,6 +143,14 @@ After opening a PR, run the review workflow to process Copilot reviewer comments
 
 This workflow fetches all inline and PR-level comments, classifies them (Valid / Invalid / Speculative), applies fixes, commits, replies, and resolves threads. Run it whenever `copilot-pull-request-reviewer` has posted comments.
 
+Copilot reviewer suggestions are the default path. Prefer accepting and implementing them unless one of these is true:
+
+- The suggestion conflicts with real application operations, runtime behavior, or deployment constraints
+- The suggestion degrades user experience for the intended flow
+- The suggestion introduces a concrete security weakness or vulnerability
+
+If a suggestion is rejected, reply with the specific evidence (file path plus section or behavior) that justifies the rejection.
+
 ## QA — invoke the qa agent after handler PRs
 
 After any PR that adds or modifies a Lambda handler in `functions/`, invoke the qa agent:

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -46,7 +46,7 @@ Use plain, professional language throughout this workflow. Do not use emojis in 
 
 4. **Classify every comment** — print a numbered list of every distinct comment with its ID. Group by file. For each comment, check the claim against the current file content and the authoritative documents from step 2. Assign exactly one classification:
 
-   For comments from Copilot, prefer the suggestion by default. Classify as **Valid** unless there is concrete evidence that applying it would (a) break or interfere with application operations, (b) degrade UX for the intended flow, or (c) introduce a security weakness or vulnerability.
+   For comments from Copilot, treat the suggestion as high-signal but not automatically correct. First verify whether the claim is correct and within scope based on the files and authoritative documents from step 2. Classify as **Valid** only when that verification shows the claim is correct and a change is warranted. If the claim is contradicted by files or docs, classify it as **Rejected**; if evidence is insufficient, classify it as **Ambiguous**. Even for a correct suggestion, reject it if applying it would (a) break or interfere with application operations, (b) degrade UX for the intended flow, or (c) introduce a security weakness or vulnerability.
 
    * **Valid** — the claim is correct; a change is warranted. State what will be changed.
    * **Rejected** — the claim contradicts the actual file content, a documented design decision, or an instruction file convention. Name the specific document and section that contradicts it. Do not act on it.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -44,6 +44,8 @@ Follow these steps exactly. Do not skip any step. To reduce potential for rate-l
 
 4. **Classify every comment** — print a numbered list of every distinct comment with its ID. Group by file. For each comment, check the claim against the current file content and the authoritative documents from step 2. Assign exactly one classification:
 
+   For comments from Copilot, prefer the suggestion by default. Classify as **✅ Valid** unless there is concrete evidence that applying it would (a) break or interfere with application operations, (b) degrade UX for the intended flow, or (c) introduce a security weakness or vulnerability.
+
    * **✅ Valid** — the claim is correct; a change is warranted. State what will be changed.
    * **❌ Rejected** — the claim contradicts the actual file content, a documented design decision, or an instruction file convention. Name the specific document and section that contradicts it. Do not act on it.
    * **⚠️ Ambiguous** — cannot be determined from available documents. Describe what is unclear and pause for user input before proceeding.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -5,6 +5,8 @@ description: Read all review comments on the current PR, validate each against a
 
 Follow these steps exactly. Do not skip any step. To reduce potential for rate-limiting, add a random 2–5 second sleep immediately before you prompt the user for approval to execute a command.
 
+Use plain, professional language throughout this workflow. Do not use emojis in classifications, replies, summaries, or any generated text.
+
 1. **Identify the PR** — run `gh pr view --json number,headRefName` to get the PR number and branch name. If the current branch has no open PR, stop and tell the user.
 
 2. **Gather authoritative context** — before reading any comments, establish the ground truth you will use to validate reviewer claims:
@@ -44,13 +46,13 @@ Follow these steps exactly. Do not skip any step. To reduce potential for rate-l
 
 4. **Classify every comment** — print a numbered list of every distinct comment with its ID. Group by file. For each comment, check the claim against the current file content and the authoritative documents from step 2. Assign exactly one classification:
 
-   For comments from Copilot, prefer the suggestion by default. Classify as **✅ Valid** unless there is concrete evidence that applying it would (a) break or interfere with application operations, (b) degrade UX for the intended flow, or (c) introduce a security weakness or vulnerability.
+   For comments from Copilot, prefer the suggestion by default. Classify as **Valid** unless there is concrete evidence that applying it would (a) break or interfere with application operations, (b) degrade UX for the intended flow, or (c) introduce a security weakness or vulnerability.
 
-   * **✅ Valid** — the claim is correct; a change is warranted. State what will be changed.
-   * **❌ Rejected** — the claim contradicts the actual file content, a documented design decision, or an instruction file convention. Name the specific document and section that contradicts it. Do not act on it.
-   * **⚠️ Ambiguous** — cannot be determined from available documents. Describe what is unclear and pause for user input before proceeding.
+   * **Valid** — the claim is correct; a change is warranted. State what will be changed.
+   * **Rejected** — the claim contradicts the actual file content, a documented design decision, or an instruction file convention. Name the specific document and section that contradicts it. Do not act on it.
+   * **Ambiguous** — cannot be determined from available documents. Describe what is unclear and pause for user input before proceeding.
 
-   Do not ask the user about ✅ Valid or ❌ Rejected comments — proceed directly for those.
+   Do not ask the user about Valid or Rejected comments — proceed directly for those.
 
 5. **Process in batches of 5–6** — work through Valid comments in groups. For each batch:
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": "docs/design.md",
         "hashed_secret": "c8b90b4e16ab2fedcb9397b5dc6a63cceb66717c",
         "is_verified": false,
-        "line_number": 1187
+        "line_number": 1189
       }
     ],
     "infra/stacks/aurora.yaml": [
@@ -204,5 +204,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-13T03:20:37Z"
+  "generated_at": "2026-04-24T03:18:35Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": "docs/design.md",
         "hashed_secret": "c8b90b4e16ab2fedcb9397b5dc6a63cceb66717c",
         "is_verified": false,
-        "line_number": 1189
+        "line_number": 1192
       }
     ],
     "infra/stacks/aurora.yaml": [
@@ -204,5 +204,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-24T03:18:35Z"
+  "generated_at": "2026-04-24T03:27:33Z"
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -706,6 +706,8 @@ Personal-device path for annual dues payment via **Stripe.js** (card element —
 | `POST` | `/v1/kiosk/guest-payment` | **Device Token** |
 | `POST` | `/v1/kiosk/waiver` | **Device Token** |
 
+**Initial API Gateway rollout scope (ODQ #29):** The following routes require **Stripe Terminal SDK** integration and are not wired to **API Gateway** until ODQ #29 is resolved: `POST /v1/kiosk/dues`, `POST /v1/kiosk/consumable-purchase`, and the NFC/Card payment steps within `POST /v1/kiosk/guest-payment` (the **Cash** path of `guest-payment` is functional without Stripe, but the full endpoint is deferred to the same milestone). All other kiosk routes — `DELETE /v1/kiosk/wait-list/{entry_id}`, `GET /v1/kiosk/range/lanes`, `POST /v1/kiosk/check-in`, `POST /v1/kiosk/check-out`, and `POST /v1/kiosk/waiver` — are ready for immediate API Gateway configuration.
+
 ---
 
 ```http

--- a/docs/design.md
+++ b/docs/design.md
@@ -708,7 +708,7 @@ Personal-device path for annual dues payment via **Stripe.js** (card element —
 
 **Initial API Gateway rollout scope (ODQ 29):**
 
-* Deferred from initial **API Gateway** wiring until ODQ 29 is resolved: `POST /v1/kiosk/dues`, `POST /v1/kiosk/consumable-purchase`, and `POST /v1/kiosk/guest-payment`. For `POST /v1/kiosk/guest-payment`, the handler logic supports a cash-only path without **Stripe**, but the route remains intentionally unwired to **API Gateway** until the same milestone resolves the full payment flow.
+* Deferred from initial **API Gateway** wiring pending **Webmaster** approval of the payment rollout: `POST /v1/kiosk/dues`, `POST /v1/kiosk/consumable-purchase`, and `POST /v1/kiosk/guest-payment`. For `POST /v1/kiosk/guest-payment`, the handler logic supports a cash-only path without **Stripe**, but the route remains intentionally unwired to **API Gateway** until the payment rollout is approved and the full payment flow is ready.
 * Ready for immediate **API Gateway** configuration: `DELETE /v1/kiosk/wait-list/{entry_id}`, `GET /v1/kiosk/range/lanes`, `POST /v1/kiosk/check-in`, `POST /v1/kiosk/check-out`, and `POST /v1/kiosk/waiver`.
 
 ---

--- a/docs/design.md
+++ b/docs/design.md
@@ -706,7 +706,10 @@ Personal-device path for annual dues payment via **Stripe.js** (card element —
 | `POST` | `/v1/kiosk/guest-payment` | **Device Token** |
 | `POST` | `/v1/kiosk/waiver` | **Device Token** |
 
-**Initial API Gateway rollout scope (ODQ #29):** The following routes require **Stripe Terminal SDK** integration and are not wired to **API Gateway** until ODQ #29 is resolved: `POST /v1/kiosk/dues`, `POST /v1/kiosk/consumable-purchase`, and the NFC/Card payment steps within `POST /v1/kiosk/guest-payment` (the **Cash** path of `guest-payment` is functional without Stripe, but the full endpoint is deferred to the same milestone). All other kiosk routes — `DELETE /v1/kiosk/wait-list/{entry_id}`, `GET /v1/kiosk/range/lanes`, `POST /v1/kiosk/check-in`, `POST /v1/kiosk/check-out`, and `POST /v1/kiosk/waiver` — are ready for immediate API Gateway configuration.
+**Initial API Gateway rollout scope (ODQ 29):**
+
+* Deferred from initial **API Gateway** wiring until ODQ 29 is resolved: `POST /v1/kiosk/dues`, `POST /v1/kiosk/consumable-purchase`, and `POST /v1/kiosk/guest-payment`. For `POST /v1/kiosk/guest-payment`, the handler logic supports a cash-only path without **Stripe**, but the route remains intentionally unwired to **API Gateway** until the same milestone resolves the full payment flow.
+* Ready for immediate **API Gateway** configuration: `DELETE /v1/kiosk/wait-list/{entry_id}`, `GET /v1/kiosk/range/lanes`, `POST /v1/kiosk/check-in`, `POST /v1/kiosk/check-out`, and `POST /v1/kiosk/waiver`.
 
 ---
 

--- a/docs/runbooks/pr-review-feedback.md
+++ b/docs/runbooks/pr-review-feedback.md
@@ -1,0 +1,31 @@
+# Runbook: Processing Copilot PR Review Feedback
+
+**Audience:** Developers and Webmaster.
+
+This runbook defines how to handle Copilot reviewer feedback on pull requests.
+
+---
+
+## Default policy
+
+Copilot reviewer suggestions are the default path. Prefer accepting and implementing suggestions unless one of these conditions is true:
+
+* The suggestion conflicts with real application operations, runtime behavior, or deployment constraints
+* The suggestion degrades user experience for the intended flow
+* The suggestion introduces a concrete security weakness or vulnerability
+
+---
+
+## Rejection standard
+
+When rejecting a Copilot suggestion, provide specific evidence in the reply:
+
+* Reference the exact file path and section, or the concrete runtime behavior that contradicts the suggestion
+* Keep the reply factual and concise
+* Do not reject based on preference alone
+
+---
+
+## Workflow note
+
+Use the PR review workflow in `.github/prompts/review.prompt.md` and the review section in `.github/instructions/pr.instructions.md` as the authoritative implementation procedure.

--- a/docs/runbooks/pr-review-feedback.md
+++ b/docs/runbooks/pr-review-feedback.md
@@ -1,6 +1,6 @@
 # Runbook: Processing Copilot PR Review Feedback
 
-**Audience:** Developers and Webmaster.
+**Audience:** Developers and **Webmaster**.
 
 This runbook defines how to handle Copilot reviewer feedback on pull requests.
 

--- a/docs/runbooks/pr-review-feedback.md
+++ b/docs/runbooks/pr-review-feedback.md
@@ -6,23 +6,27 @@ This runbook defines how to handle Copilot reviewer feedback on pull requests.
 
 ---
 
-## Default policy
+## Policy reference
 
-Copilot reviewer suggestions are the default path. Prefer accepting and implementing suggestions unless one of these conditions is true:
+Do not restate acceptance and rejection policy in this runbook.
 
-* The suggestion conflicts with real application operations, runtime behavior, or deployment constraints
-* The suggestion degrades user experience for the intended flow
-* The suggestion introduces a concrete security weakness or vulnerability
+Use the review section in `.github/instructions/pr.instructions.md` and the workflow in `.github/prompts/review.prompt.md` as the canonical source of truth for:
+
+* when to accept or reject Copilot reviewer suggestions
+* what evidence is required when replying to or rejecting a suggestion
+* how to process review comments and resolve threads
 
 ---
 
-## Rejection standard
+## Procedure
 
-When rejecting a Copilot suggestion, provide specific evidence in the reply:
-
-* Reference the exact file path and section, or the concrete runtime behavior that contradicts the suggestion
-* Keep the reply factual and concise
-* Do not reject based on preference alone
+1. Open the pull request and fetch all Copilot review comments, including inline comments and PR-level comments.
+2. Read each comment and classify it using the canonical policy references above.
+3. For accepted comments, make the smallest change needed to address the feedback without expanding scope.
+4. For rejected comments, reply with specific evidence that cites the exact file path and section or the concrete runtime behavior that contradicts the suggestion.
+5. Re-run the required checks for the files you changed and confirm the pull request is still ready for review.
+6. Reply to each review thread with the fix summary or rejection evidence, then resolve the thread when the response is complete.
+7. If Copilot posts another review round, repeat this procedure until all valid comments are addressed.
 
 ---
 

--- a/docs/runbooks/pr-review-feedback.md
+++ b/docs/runbooks/pr-review-feedback.md
@@ -8,7 +8,7 @@ This runbook defines how to handle Copilot reviewer feedback on pull requests.
 
 ## Policy reference
 
-Do not restate acceptance and rejection policy in this runbook.
+Do not restate the acceptance and rejection policy in this runbook.
 
 Use the review section in `.github/instructions/pr.instructions.md` and the workflow in `.github/prompts/review.prompt.md` as the canonical source of truth for:
 
@@ -32,4 +32,4 @@ Use the review section in `.github/instructions/pr.instructions.md` and the work
 
 ## Workflow note
 
-Use the PR review workflow in `.github/prompts/review.prompt.md` and the review section in `.github/instructions/pr.instructions.md` as the authoritative implementation procedure.
+This runbook is a concise procedure checklist. Use `.github/prompts/review.prompt.md` for the detailed workflow and `.github/instructions/pr.instructions.md` for the governing policy.


### PR DESCRIPTION
## Summary

Pre-flight audit for the kiosk surface rollout, plus follow-up documentation that codifies how Copilot PR review feedback is handled. Confirms all eight kiosk Lambda functions are defined in `infra/stacks/lambda.yaml`, reconciles `docs/design.md` Section 7.2 with the current API Gateway state, and aligns the review workflow documentation added during PR feedback.

## Changes

- `docs/design.md` — Added and clarified the Section 7.2 kiosk rollout scope note so the deferred payment routes are explicitly gated by pending Webmaster approval of the payment rollout.
- `docs/runbooks/pr-review-feedback.md` — Added a procedural runbook for processing Copilot review feedback while deferring policy to the canonical workflow and PR instruction files.
- `.github/prompts/review.prompt.md` — Updated the review workflow prompt terminology and Copilot suggestion handling guidance to match the canonical PR workflow.
- `.github/instructions/pr.instructions.md` — Documented the default acceptance policy for Copilot reviewer suggestions and aligned review classification names with the prompt.
- `.secrets.baseline` — Refreshed detect-secrets metadata after documentation line shifts.

## Motivation

Before wiring kiosk routes in API Gateway (M1), this PR establishes a clear baseline for the kiosk rollout and then incorporates the review workflow clarifications prompted during review:

- All eight kiosk Lambda functions were confirmed present in `lambda.yaml`.
- ODQ 29 already captures the payment hold, but Section 7.2 needed an inline rollout note so an implementer wiring M1 would not have to cross-reference Section 11 route-by-route.
- Follow-up PR review feedback added workflow-policy clarifications; those changes are now reflected in the prompt, PR instructions, and a procedural runbook without duplicating canonical policy text.

Related to the kiosk surface rollout plan (M0).

## Security considerations

None — docs-only and workflow-documentation changes.

## Testing

pymarkdown scan passes: `pymarkdown scan -r docs/ README.md` — no errors.

No handler or infra files changed; pytest and cfn-lint not required.

## Breaking changes

None.
