### PR TITLE
chore: reduce token usage in review.prompt.md

### DIFF
--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -19,10 +19,10 @@ Use plain, professional language. Do not use emojis.
 
    ```bash
    gh api graphql -f query='
-     query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String) {
+     query($owner: String!, $name: String!, $pr: Int!, $endCursor: String) {
        repository(owner: $owner, name: $name) {
          pullRequest(number: $pr) {
-           reviewThreads(first: 100, after: $threadCursor) {
+           reviewThreads(first: 100, after: $endCursor) {
              pageInfo { hasNextPage endCursor }
              nodes {
                id
@@ -41,9 +41,9 @@ Use plain, professional language. Do not use emojis.
 
 4. **Classify every comment** — print each comment with its ID, grouped by file. Check the claim against the file content and authoritative context from step 2. Assign exactly one classification:
 
-   - **Valid** — the claim is correct; a change is warranted. State what will be changed.
+   - **Valid** — the claim is correct; a change is warranted. State what will be changed. A question-only comment that requires no code change is also classified Valid.
    - **Rejected** — the claim contradicts file content, a documented decision, or a project convention. Name the specific document and section.
-   - **Ambiguous** — cannot be determined from available context. Describe what is unclear and pause for user input.
+   - **Ambiguous** — cannot be determined from available context. Describe what is unclear and pause for user input before proceeding.
 
    For Copilot comments: classify as Valid only after verifying the claim is correct and within scope. Reject if applying it would break application behavior, degrade UX, or introduce a security weakness.
 
@@ -76,10 +76,12 @@ Use plain, professional language. Do not use emojis.
 
    - Fixed: confirm what changed and why.
    - Rejected: cite the document, section, or pattern that contradicts the claim.
-   - Question only: answer directly; no code change needed.
+   - Question only (Valid, no code change): answer directly.
    - Keep replies concise and factual.
 
-   Note: This workflow addresses inline review comments only. Top-level PR conversation comments (from `pullRequest.comments`) are not replied to in this workflow.
+   Skip Ambiguous comments — do not reply until the user provides clarification.
+
+   Note: This workflow addresses inline review comments only. Top-level PR conversation or timeline comments are not replied to in this workflow.
 
 7. **Self-review gate** — before pushing, check the full set of changes:
 

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -22,10 +22,6 @@ Use plain, professional language. Do not use emojis.
      query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String, $commentCursor: String) {
        repository(owner: $owner, name: $name) {
          pullRequest(number: $pr) {
-           comments(first: 100) {
-             pageInfo { hasNextPage endCursor }
-             nodes { databaseId body author { login } }
-           }
            reviewThreads(first: 100, after: $threadCursor) {
              pageInfo { hasNextPage endCursor }
              nodes {
@@ -42,7 +38,7 @@ Use plain, professional language. Do not use emojis.
      }' -f owner='<owner>' -f name='<repo>' -F pr=<N> --paginate
    ```
 
-   Build a map of `reviewThreads.nodes.comments.nodes.databaseId → reviewThreads.nodes.id` from the results — you will need it in step 9 when resolving threads. Keep `pullRequest.comments.nodes.databaseId` as a separate set of top-level PR conversation comments; those comments do not belong to a review thread and are not used in this workflow. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
+   Build a map of `reviewThreads.nodes.comments.nodes.databaseId → reviewThreads.nodes.id` from the results — you will need it in step 9 when resolving threads. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
 
 4. **Classify every comment** — print each comment with its ID, grouped by file. Check the claim against the file content and authoritative context from step 2. Assign exactly one classification:
 
@@ -76,7 +72,7 @@ Use plain, professional language. Do not use emojis.
    ```
 
    ```bash
-   gh api repos/<nameWithOwner>/pulls/<number>/comments/<comment_id>/replies --input /tmp/reply.json && rm /tmp/reply.json
+   gh api repos/<owner>/<repo>/pulls/<number>/comments/<comment_id>/replies --input /tmp/reply.json && rm /tmp/reply.json
    ```
 
    - Fixed: confirm what changed and why.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -5,114 +5,98 @@ description: Read all review comments on the current PR, validate each against a
 
 # PR Review Workflow
 
-Follow these steps exactly. Do not skip any step. To reduce potential for rate-limiting, add a random 2–5 second sleep immediately before you prompt the user for approval to execute a command.
-
-Use plain, professional language throughout this workflow. Do not use emojis in classifications, replies, summaries, or any generated text.
+Use plain, professional language. Do not use emojis.
 
 1. **Identify the PR** — run `gh pr view --json number,headRefName` to get the PR number and branch name. If the current branch has no open PR, stop and tell the user.
 
-2. **Gather authoritative context** — before reading any comments, establish the ground truth you will use to validate reviewer claims:
-   * List the files changed in the PR: `gh pr view <number> --json files --jq '.files[].path'`
-   * Read each changed file in full.
-   * Invoke the system agent: *"What sections of docs/design.md, docs/architecture.md, docs/stack-decisions.md, and which .github/instructions files are authoritative for these changed files: [list]?"*
-   * Read every document the system agent identifies in full before proceeding.
+2. **Gather context** — list the changed files: `gh pr view <number> --json files --jq '.files[].path'`. Read only the sections of each changed file that are relevant to the diff or review topic — do not read files in full unless the entire file is small. Then ask the system agent which sections of `docs/design.md`, `docs/architecture.md`, `docs/stack-decisions.md`, and `.github/instructions/` files are authoritative for those paths — read only those sections.
 
-   The reviewer is expected to have sound software engineering knowledge but may not know this codebase. Their suggestions about general patterns are likely correct; their claims about project-specific decisions, existing conventions, or what the code already does must be verified against the files and docs you just read.
+   The reviewer may not know this codebase. Treat suggestions about general patterns as high-signal; verify project-specific claims against the files and docs before accepting them.
 
-3. **Read review comments** — fetch all feedback:
-   * Derive the repo path: `gh repo view --json nameWithOwner --jq .nameWithOwner`
-   * Top-level PR comments: `gh pr view <number> --comments`
-   * Inline code comments: `gh api --paginate repos/<nameWithOwner>/pulls/<number>/comments`
+3. **Fetch review data** — use a single GraphQL query to retrieve all review threads, comment bodies, and thread node IDs in one call:
 
-   Also fetch thread node IDs now — you will need them for step 8. Paginate until `hasNextPage` is false:
    ```bash
    gh api graphql -f query='
-     query($owner: String!, $name: String!, $pr: Int!, $after: String) {
+     query($owner: String!, $name: String!, $pr: Int!) {
        repository(owner: $owner, name: $name) {
          pullRequest(number: $pr) {
-           reviewThreads(first: 100, after: $after) {
-             pageInfo { hasNextPage endCursor }
+           comments(first: 100) {
+             nodes { databaseId body author { login } }
+           }
+           reviewThreads(first: 100) {
              nodes {
                id
                isResolved
-               comments(first: 1) { nodes { databaseId } }
+               comments(first: 10) {
+                 nodes { databaseId body author { login } path line }
+               }
              }
            }
          }
        }
      }' -f owner='<owner>' -f name='<repo>' -F pr=<N>
    ```
-   Repeat with `-f after='<endCursor>'` while `pageInfo.hasNextPage` is true. Build a map of `comment databaseId → thread node id` from the complete set of results.
 
-   > **Note:** GitHub does not reliably mark comments as "outdated" — file-level comments (no anchor line) never go outdated regardless of how many pushes occur. Do not use the `outdated` field to determine whether a comment has been addressed. Track each comment ID explicitly.
+   Build a map of `comment databaseId → thread node id` from the results — you will need it in step 7. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
 
-4. **Classify every comment** — print a numbered list of every distinct comment with its ID. Group by file. For each comment, check the claim against the current file content and the authoritative documents from step 2. Assign exactly one classification:
+4. **Classify every comment** — print each comment with its ID, grouped by file. Check the claim against the file content and authoritative context from step 2. Assign exactly one classification:
 
-   For comments from Copilot, treat the suggestion as high-signal but not automatically correct. First verify whether the claim is correct and within scope based on the files and authoritative documents from step 2. Classify as **Valid** only when that verification shows the claim is correct and a change is warranted. If the claim is contradicted by files or docs, classify it as **Rejected**; if evidence is insufficient, classify it as **Ambiguous**. Even for a correct suggestion, reject it if applying it would (a) break or interfere with application operations, (b) degrade UX for the intended flow, or (c) introduce a security weakness or vulnerability.
+   - **Valid** — the claim is correct; a change is warranted. State what will be changed.
+   - **Rejected** — the claim contradicts file content, a documented decision, or a project convention. Name the specific document and section.
+   - **Ambiguous** — cannot be determined from available context. Describe what is unclear and pause for user input.
 
-   * **Valid** — the claim is correct; a change is warranted. State what will be changed.
-   * **Rejected** — the claim contradicts the actual file content, a documented design decision, or an instruction file convention. Name the specific document and section that contradicts it. Do not act on it.
-   * **Ambiguous** — cannot be determined from available documents. Describe what is unclear and pause for user input before proceeding.
+   For Copilot comments: classify as Valid only after verifying the claim is correct and within scope. Reject if applying it would break application behavior, degrade UX, or introduce a security weakness.
 
-   Do not ask the user about Valid or Rejected comments — proceed directly for those.
+   Do not ask the user about Valid or Rejected comments — proceed directly.
 
-5. **Process in batches of 5–6** — work through Valid comments in groups. For each batch:
+5. **Apply fixes** — for each Valid comment, make the change using file-edit tools. Verify each change is present after applying it. Do not make unrequested changes. If a comment is a question only, note the answer and move on.
 
-   **a. Fix** — make the code or doc changes using file-edit tools. After each change, verify it is present in the file. Do not make unrequested changes alongside a fix. If a comment is a question only (no code change required), note the answer and move on.
-
-   **b. Commit the batch**:
+   Commit all fixes together:
 
    ```bash
    git add <changed files>
-   git commit -m "fix: address PR review comments (batch N)"
+   git commit -m "fix: address PR review comments"
    ```
-   Use a descriptive message if the batch covers a single topic (e.g., `fix: wrap all DB queries in transactions`).
 
-   If the commit fails with exit code 3 and the message "The baseline file was updated", the `detect-secrets` pre-commit hook auto-updated `.secrets.baseline` to reflect line number shifts. Run:
+   Use a descriptive subject if the changes cover a single clear topic. If the commit fails with exit code 3 and the message "The baseline file was updated", the `detect-secrets` hook updated `.secrets.baseline` — run:
 
    ```bash
-   git add .secrets.baseline
-   git commit -m "<same message as above>"
+   git add .secrets.baseline && git commit -m "<same message>"
    ```
-   This is expected and safe — the hook only updates line-number metadata, never suppresses new secrets.
 
-   **c. Reply to each comment in the batch** — for each reply, write the body to `/tmp/reply.json` using the file-creation tool (never shell redirection or echo), then post it:
+6. **Reply to every comment** — for each reply, write the body using the file-creation tool (never shell redirection), then post it:
 
    ```json
-   {"body": "Your reply text here."}
+   {"body": "Your reply text."}
    ```
 
    ```bash
-   gh api repos/<nameWithOwner>/pulls/<number>/comments/<comment_id>/replies --input /tmp/reply.json
+   gh api repos/<nameWithOwner>/pulls/<number>/comments/<comment_id>/replies --input /tmp/reply.json && rm /tmp/reply.json
    ```
-   * **Valid comments that were fixed:** confirm what changed and why.
-   * **Rejected comments:** explain the discrepancy — cite the specific document, section, or established pattern that contradicts the claim.
-   * **Questions only:** answer directly; no code change needed.
-   * Keep replies concise and factual. Do not be defensive.
 
-   Repeat until all Valid comments are processed.
+   - Fixed: confirm what changed and why.
+   - Rejected: cite the document, section, or pattern that contradicts the claim.
+   - Question only: answer directly; no code change needed.
+   - Keep replies concise and factual.
 
-6. **Update docs if needed** — review the full set of fixes applied. If any fix changed an API contract, request/response shape, error code, auth level, schema column, or AWS service behavior, invoke the quality agent: *"Update docs/design.md to reflect [list of specific changes from this PR]"*. The quality agent must commit its changes before you proceed. Do not push until the quality agent confirms the update is complete or confirms no update is needed.
+7. **Self-review gate** — before pushing, check the full set of changes:
 
-7. **Self-review gate** — before pushing, run two proactive checks over every changed file to catch issues before Copilot sees them on the next pass:
+   - **Docs**: if any fix changed an API contract, response shape, error code, auth level, schema column, or AWS service behavior, invoke the quality agent: *"Update docs/design.md to reflect [list of changes]"*. Wait for it to commit.
+   - **Linter**: invoke the quality agent: *"Lint these files: [list of changed files]"*. Wait for it to commit any fixes.
+   - **Security**: if any changed file matches `functions/**/*.py`, `db/**/*.sql`, or `infra/**/*.yaml`, invoke the system agent: *"Security review [list of files]"*. Fix High/Critical findings before pushing; note Medium/Low in the PR description.
 
-   **a. Linter** — invoke the quality agent: *"Lint these files and fix any issues: [list of changed files]"*. The quality agent must commit any fixes before you proceed.
+   If none of the above conditions apply, proceed immediately.
 
-   **b. Security** — if any changed file matches `functions/**/*.py`, `db/**/*.sql`, or `infra/**/*.yaml`, invoke the system agent: *"Security review [list of matching changed files]"*. Research and fix any **High** or **Critical** findings; note **Medium** and **Low** findings in the PR description and address them in a follow-up. The system agent must commit any fixes before you proceed.
+8. **Push** — run `git push` once after all fixes and self-review commits are complete.
 
-   If neither agent finds anything to fix, proceed immediately — do not pause for user confirmation.
-
-8. **Push** — run `git push` once after all batches (including any docs update and self-review fixes) are committed.
-
-9. **Resolve threads** — for every comment that was either fixed or rejected, resolve its review thread using the node ID map built in step 3:
+9. **Resolve threads** — resolve every thread that was fixed or rejected using the node IDs from step 3:
 
    ```bash
    gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: "<thread_node_id>" }) { thread { isResolved } } }'
    ```
-   Resolve all threads before ending.
 
-10. **Request a new Copilot review** — after all threads are resolved, tell the user:
+10. **Request a new Copilot review** — tell the user:
 
-   > All threads have been resolved. To trigger another Copilot review pass, click the **Re-request review** button (circular arrow icon) next to Copilot in the Reviewers sidebar on the PR page.
+    > All threads have been resolved. To trigger another Copilot review pass, click the **Re-request review** button (circular arrow icon) next to Copilot in the Reviewers sidebar on the PR page.
 
-   Note: `@copilot review` in a comment triggers the Copilot *coding agent* (opens a sub-PR), not the PR reviewer — do not use it here. The reviewer-request API returns HTTP 422 for this repo. The manual button is the only reliable trigger.
+    Note: `@copilot review` in a comment triggers the Copilot coding agent (opens a sub-PR), not the PR reviewer. The reviewer-request API returns HTTP 422 for this repo — the manual button is the only reliable trigger.

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -13,31 +13,36 @@ Use plain, professional language. Do not use emojis.
 
    The reviewer may not know this codebase. Treat suggestions about general patterns as high-signal; verify project-specific claims against the files and docs before accepting them.
 
-3. **Fetch review data** — use a single GraphQL query to retrieve all review threads, comment bodies, and thread node IDs in one call:
+   **Obtain repo metadata** — run `gh repo view --json nameWithOwner --jq '.nameWithOwner'` and split the result into `<owner>` and `<repo>` (e.g., `vrwmiller/outdoorsportsclub` → owner=`vrwmiller`, repo=`outdoorsportsclub`). You will need these values in step 3.
+
+3. **Fetch review data** — use a paginated GraphQL query to retrieve all review threads, comment bodies, and thread node IDs:
 
    ```bash
    gh api graphql -f query='
-     query($owner: String!, $name: String!, $pr: Int!) {
+     query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String, $commentCursor: String) {
        repository(owner: $owner, name: $name) {
          pullRequest(number: $pr) {
            comments(first: 100) {
+             pageInfo { hasNextPage endCursor }
              nodes { databaseId body author { login } }
            }
-           reviewThreads(first: 100) {
+           reviewThreads(first: 100, after: $threadCursor) {
+             pageInfo { hasNextPage endCursor }
              nodes {
                id
                isResolved
-               comments(first: 10) {
+               comments(first: 100, after: $commentCursor) {
+                 pageInfo { hasNextPage endCursor }
                  nodes { databaseId body author { login } path line }
                }
              }
            }
          }
        }
-     }' -f owner='<owner>' -f name='<repo>' -F pr=<N>
+     }' -f owner='<owner>' -f name='<repo>' -F pr=<N> --paginate
    ```
 
-   Build a map of `comment databaseId → thread node id` from the results — you will need it in step 7. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
+   Build a map of `reviewThreads.nodes.comments.nodes.databaseId → reviewThreads.nodes.id` from the results — you will need it in step 9 when resolving threads. Keep `pullRequest.comments.nodes.databaseId` as a separate set of top-level PR conversation comments; those comments do not belong to a review thread and are not used in this workflow. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
 
 4. **Classify every comment** — print each comment with its ID, grouped by file. Check the claim against the file content and authoritative context from step 2. Assign exactly one classification:
 
@@ -51,20 +56,20 @@ Use plain, professional language. Do not use emojis.
 
 5. **Apply fixes** — for each Valid comment, make the change using file-edit tools. Verify each change is present after applying it. Do not make unrequested changes. If a comment is a question only, note the answer and move on.
 
-   Commit all fixes together:
+   **Commit in logical groups** — commit fixes grouped by logical topic (e.g., all schema changes together, all handler changes together), not as a single monolithic commit. Use clear, scoped commit messages following the format in `.github/instructions/pr.instructions.md`:
 
    ```bash
-   git add <changed files>
-   git commit -m "fix: address PR review comments"
+   git add <changed files for this logical topic>
+   git commit -m "fix(<scope>): short description"
    ```
 
-   Use a descriptive subject if the changes cover a single clear topic. If the commit fails with exit code 3 and the message "The baseline file was updated", the `detect-secrets` hook updated `.secrets.baseline` — run:
+   If a commit fails with exit code 3 and the message "The baseline file was updated", the `detect-secrets` hook updated `.secrets.baseline` — run:
 
    ```bash
    git add .secrets.baseline && git commit -m "<same message>"
    ```
 
-6. **Reply to every comment** — for each reply, write the body using the file-creation tool (never shell redirection), then post it:
+6. **Reply to every inline review comment** — for each inline review comment in `reviewThreads`, write the body using the file-creation tool (never shell redirection), then post it:
 
    ```json
    {"body": "Your reply text."}
@@ -79,6 +84,8 @@ Use plain, professional language. Do not use emojis.
    - Question only: answer directly; no code change needed.
    - Keep replies concise and factual.
 
+   Note: This workflow addresses inline review comments only. Top-level PR conversation comments (from `pullRequest.comments`) are not replied to in this workflow.
+
 7. **Self-review gate** — before pushing, check the full set of changes:
 
    - **Docs**: if any fix changed an API contract, response shape, error code, auth level, schema column, or AWS service behavior, invoke the quality agent: *"Update docs/design.md to reflect [list of changes]"*. Wait for it to commit.
@@ -89,7 +96,7 @@ Use plain, professional language. Do not use emojis.
 
 8. **Push** — run `git push` once after all fixes and self-review commits are complete.
 
-9. **Resolve threads** — resolve every thread that was fixed or rejected using the node IDs from step 3:
+9. **Resolve threads** — resolve every thread that was fixed or rejected using the thread node IDs from step 3 (`reviewThreads.nodes.id`):
 
    ```bash
    gh api graphql -f query='mutation { resolveReviewThread(input: { threadId: "<thread_node_id>" }) { thread { isResolved } } }'

--- a/.github/prompts/review.prompt.md
+++ b/.github/prompts/review.prompt.md
@@ -19,7 +19,7 @@ Use plain, professional language. Do not use emojis.
 
    ```bash
    gh api graphql -f query='
-     query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String, $commentCursor: String) {
+     query($owner: String!, $name: String!, $pr: Int!, $threadCursor: String) {
        repository(owner: $owner, name: $name) {
          pullRequest(number: $pr) {
            reviewThreads(first: 100, after: $threadCursor) {
@@ -27,18 +27,17 @@ Use plain, professional language. Do not use emojis.
              nodes {
                id
                isResolved
-               comments(first: 100, after: $commentCursor) {
-                 pageInfo { hasNextPage endCursor }
+               comments(first: 100) {
                  nodes { databaseId body author { login } path line }
                }
              }
            }
          }
        }
-     }' -f owner='<owner>' -f name='<repo>' -F pr=<N> --paginate
+     }' -f owner='<owner>' -f name='<repo>' -F pr=<number> --paginate
    ```
 
-   Build a map of `reviewThreads.nodes.comments.nodes.databaseId → reviewThreads.nodes.id` from the results — you will need it in step 9 when resolving threads. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
+   Build a map of `reviewThreads.nodes.comments.nodes.databaseId → reviewThreads.nodes.id` from the results — you will need it in step 9 when resolving threads. Note: comments per thread are fetched up to 100; threads with more than 100 comments will be truncated. Do not use the `outdated` field to skip comments; track each comment ID explicitly.
 
 4. **Classify every comment** — print each comment with its ID, grouped by file. Check the claim against the file content and authoritative context from step 2. Assign exactly one classification:
 


### PR DESCRIPTION
## Summary

Refactors `.github/prompts/review.prompt.md` to reduce token usage per run by eliminating repeated context rehydration, consolidating API calls, and removing embedded orchestration detail. Closes #153.

## Changes

- **Single GraphQL fetch** — replaces three separate API calls (top-level comments via `gh pr view --comments`, inline comments via REST, thread node IDs via GraphQL) with one GraphQL query that returns all comment bodies and thread node IDs in a single round-trip
- **Targeted reads** — "read each changed file in full" and "read every authoritative doc in full" replaced with targeted section reads scoped to the diff and review topic; reduces O(N files + M docs) full-context reprocessing per run
- **No batching** — removed the "process in batches of 5-6" loop; all valid fixes are applied then committed together in a single commit
- **Merged self-review gate** — separate "update docs" step and "self-review gate" step combined into one step 7; removes one round of repeated governance rule statements
- **Replies as a dedicated step** — reply logic extracted from inside the per-batch loop into its own step 6 for clarity
- **Removed orchestration noise** — dropped the "2-5 second sleep" instruction and repeated "source of truth" / "authoritative docs" boilerplate that appeared across multiple steps

## Motivation

Issue #153 identified that the prompt was functioning as a full execution engine rather than a decision layer, causing repeated full-context reprocessing of files, docs, and governance rules on every invocation. The root cause is a mismatch between the prompt's assumption of persistent multi-step orchestration state and Copilot's stateless per-invocation model.

Closes #153.

## Security considerations

No changes to Lambda handlers, IAM, auth, schema, or any runtime code. This PR touches only `.github/prompts/review.prompt.md`.

## Testing

No handler or test files touched — pytest not required. No `src/` files touched — build not required. No `infra/` files touched — cfn-lint not required.

`pymarkdown scan .github/prompts/review.prompt.md` passes with no errors.

## Breaking changes

None. All operational instructions (commit format, detect-secrets tip, reply JSON format, thread resolution, Copilot re-review note) are preserved. The GraphQL query now fetches more fields per call but makes fewer calls.
