### PR TITLE
feat: expose admin pairing-code route for kiosk token bootstrap

### DIFF
--- a/docs/runbooks/kiosk-provisioning.md
+++ b/docs/runbooks/kiosk-provisioning.md
@@ -144,12 +144,12 @@ A `502 Bad Gateway` on any route means API Gateway cannot reach the Lambda. Chec
 
 ## 7. Temporary desktop token bootstrap (until Admin Portal UI is shipped)
 
-If the Admin Portal UI for device provisioning is not yet available, a Webmaster can bootstrap a temporary test device token directly from a desktop using the API routes.
+If the Admin Portal UI for device provisioning is not yet available, a Webmaster can bootstrap a temporary test device token directly from a desktop using the API routes. Use this only in `dev` for short-lived smoke testing with synthetic device records; routine kiosk provisioning and revocation still belong in the Admin Portal flow above.
 
 1. Acquire a valid Level 6 Cognito ID token and export it as `ADMIN_ID_TOKEN`
 2. Create a pairing code via `POST /v1/admin/devices/pairing-code`
 3. Exchange that code via `POST /v1/devices/pair` to receive `device_token`
-4. Use the token for kiosk route smoke tests, then revoke the device from the Admin Portal when available
+4. Use the token for kiosk route smoke tests, then mark the temporary device row `Revoked` directly in Aurora using the `device_id` returned by step 2; once the Admin Portal device management UI exists, use that UI instead
 
 ```bash
 API_BASE="https://<rest-api-id>.execute-api.us-east-1.amazonaws.com/dev"
@@ -165,6 +165,7 @@ PAIRING_RESPONSE=$(curl -s \
   "$API_BASE/v1/admin/devices/pairing-code")
 
 PAIRING_CODE=$(echo "$PAIRING_RESPONSE" | jq -r '.pairing_code')
+DEVICE_ID=$(echo "$PAIRING_RESPONSE" | jq -r '.device_id')
 
 # 2) Exchange pairing code for device token
 PAIR_RESPONSE=$(curl -s \
@@ -180,6 +181,16 @@ curl -s -o /dev/null -w "%{http_code}" \
   -H "x-device-token: $DEVICE_TOKEN" \
   "$API_BASE/v1/kiosk/range/lanes"
 ```
+
+After smoke testing, revoke the temporary device row directly in Aurora until the Admin Portal device management UI ships:
+
+```sql
+UPDATE devices
+SET status = 'Revoked'
+WHERE id = '<device_id-from-PAIRING_RESPONSE>';
+```
+
+For the shell example above, substitute the value captured in `DEVICE_ID`.
 
 Expected outcomes:
 

--- a/docs/runbooks/kiosk-provisioning.md
+++ b/docs/runbooks/kiosk-provisioning.md
@@ -139,3 +139,50 @@ curl -s -o /dev/null -w "%{http_code}" \
 ```
 
 A `502 Bad Gateway` on any route means API Gateway cannot reach the Lambda. Check that the Lambda `Permission` resource was deployed, then confirm the exact function name in `infra/stacks/lambda.yaml` rather than guessing from the route path — route path segments do not always match the function name directly (for example, `/v1/kiosk/check-in` maps to `osc-kiosk-checkin-<env>` and `/v1/kiosk/check-out` maps to `osc-kiosk-checkout-<env>`). See [ci-deployment-failure.md](ci-deployment-failure.md) for general troubleshooting steps.
+
+---
+
+## 7. Temporary desktop token bootstrap (until Admin Portal UI is shipped)
+
+If the Admin Portal UI for device provisioning is not yet available, a Webmaster can bootstrap a temporary test device token directly from a desktop using the API routes.
+
+1. Acquire a valid Level 6 Cognito ID token and export it as `ADMIN_ID_TOKEN`
+2. Create a pairing code via `POST /v1/admin/devices/pairing-code`
+3. Exchange that code via `POST /v1/devices/pair` to receive `device_token`
+4. Use the token for kiosk route smoke tests, then revoke the device from the Admin Portal when available
+
+```bash
+API_BASE="https://<rest-api-id>.execute-api.us-east-1.amazonaws.com/dev"
+RANGE_ID="<uuid-for-target-range>"
+LOCATION_TAG="Desktop-Temp-Kiosk-$(date +%s)"
+
+# 1) Create pairing code as Level 6 Webmaster
+PAIRING_RESPONSE=$(curl -s \
+  -X POST \
+  -H "Authorization: Bearer $ADMIN_ID_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"location_tag\":\"$LOCATION_TAG\",\"range_id\":\"$RANGE_ID\"}" \
+  "$API_BASE/v1/admin/devices/pairing-code")
+
+PAIRING_CODE=$(echo "$PAIRING_RESPONSE" | jq -r '.pairing_code')
+
+# 2) Exchange pairing code for device token
+PAIR_RESPONSE=$(curl -s \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"pairing_code\":\"$PAIRING_CODE\"}" \
+  "$API_BASE/v1/devices/pair")
+
+DEVICE_TOKEN=$(echo "$PAIR_RESPONSE" | jq -r '.device_token')
+
+# 3) Example kiosk smoke request with the temporary device token
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "x-device-token: $DEVICE_TOKEN" \
+  "$API_BASE/v1/kiosk/range/lanes"
+```
+
+Expected outcomes:
+
+* `POST /v1/admin/devices/pairing-code` returns `201` with `pairing_code`
+* `POST /v1/devices/pair` returns `200` with `device_token`
+* `GET /v1/kiosk/range/lanes` returns `200` (valid token) or `403` (revoked token)

--- a/functions/admin/devices-pairing-code/handler.py
+++ b/functions/admin/devices-pairing-code/handler.py
@@ -197,7 +197,7 @@ def handler(event: dict, context: Any) -> dict:
                 sql=(
                     "INSERT INTO devices "
                     "(location_tag, range_id, status, pairing_code, pairing_code_expires_at) "
-                    "VALUES (:tag, :rid, 'Pending-Pairing', :code, :expires_at::TIMESTAMPTZ) "
+                    "VALUES (:tag, :rid::uuid, 'Pending-Pairing', :code, :expires_at::TIMESTAMPTZ) "
                     "RETURNING id"
                 ),
                 parameters=[

--- a/infra/stacks/api-gateway.yaml
+++ b/infra/stacks/api-gateway.yaml
@@ -22,7 +22,7 @@ Parameters:
 
   DeploymentVersion:
     Type: String
-    Default: "2"
+    Default: "3"
     Description: >-
       Increment this value to force a new API Gateway deployment when method or
       integration changes would not otherwise cause CloudFormation to replace
@@ -258,6 +258,88 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
       SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/POST/v1/devices/pair"
+
+  # ---------------------------------------------------------------------------
+  # Resources — /v1/admin/devices/pairing-code
+  # ---------------------------------------------------------------------------
+  AdminResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref RestApi
+      ParentId: !Ref V1Resource
+      PathPart: admin
+
+  AdminDevicesResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref RestApi
+      ParentId: !Ref AdminResource
+      PathPart: devices
+
+  AdminDevicesPairingCodeResource:
+    Type: AWS::ApiGateway::Resource
+    Properties:
+      RestApiId: !Ref RestApi
+      ParentId: !Ref AdminDevicesResource
+      PathPart: pairing-code
+
+  # ---------------------------------------------------------------------------
+  # POST /v1/admin/devices/pairing-code — Cognito auth, Lambda proxy
+  # ---------------------------------------------------------------------------
+  AdminDevicesPairingCodePostMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref RestApi
+      ResourceId: !Ref AdminDevicesPairingCodeResource
+      HttpMethod: POST
+      AuthorizationType: COGNITO_USER_POOLS
+      AuthorizerId: !Ref CognitoAuthorizer
+      Integration:
+        Type: AWS_PROXY
+        IntegrationHttpMethod: POST
+        Uri: !Sub
+          - "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:osc-admin-devices-pairing-code-${Environment}/invocations"
+          - {}
+
+  # ---------------------------------------------------------------------------
+  # OPTIONS /v1/admin/devices/pairing-code — CORS preflight, no auth
+  # ---------------------------------------------------------------------------
+  AdminDevicesPairingCodeOptionsMethod:
+    Type: AWS::ApiGateway::Method
+    Properties:
+      RestApiId: !Ref RestApi
+      ResourceId: !Ref AdminDevicesPairingCodeResource
+      HttpMethod: OPTIONS
+      AuthorizationType: NONE
+      Integration:
+        Type: MOCK
+        RequestTemplates:
+          application/json: '{"statusCode": 200}'
+        IntegrationResponses:
+          - StatusCode: "200"
+            ResponseParameters:
+              method.response.header.Access-Control-Allow-Headers: "'Content-Type,Authorization'"
+              method.response.header.Access-Control-Allow-Methods: "'POST,OPTIONS'"
+              method.response.header.Access-Control-Allow-Origin: !Sub "'${CorsAllowOrigin}'"
+            ResponseTemplates:
+              application/json: "{}"
+      MethodResponses:
+        - StatusCode: "200"
+          ResponseParameters:
+            method.response.header.Access-Control-Allow-Headers: true
+            method.response.header.Access-Control-Allow-Methods: true
+            method.response.header.Access-Control-Allow-Origin: true
+
+  # ---------------------------------------------------------------------------
+  # Lambda permission — allow API Gateway to invoke admin devices-pairing-code
+  # ---------------------------------------------------------------------------
+  AdminDevicesPairingCodePostPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub "osc-admin-devices-pairing-code-${Environment}"
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*/POST/v1/admin/devices/pairing-code"
 
   # ===========================================================================
   # Kiosk routes — /v1/kiosk/**
@@ -606,6 +688,9 @@ Resources:
       - MemberMeOptionsMethod
       - DevicesPairPostMethod
       - DevicesPairOptionsMethod
+      - AdminDevicesPairingCodePostMethod
+      - AdminDevicesPairingCodeOptionsMethod
+      - AdminDevicesPairingCodePostPermission
       - KioskCheckInPostMethod
       - KioskCheckInOptionsMethod
       - KioskCheckInPostPermission
@@ -623,7 +708,7 @@ Resources:
       - KioskWaitListEntryDeletePermission
     Properties:
       RestApiId: !Ref RestApi
-      Description: !Sub "v${DeploymentVersion} — GET /v1/members/me, POST /v1/devices/pair, kiosk check-in/check-out/waiver/range-lanes/waitlist-cancel (${Environment})"
+      Description: !Sub "v${DeploymentVersion} — GET /v1/members/me, POST /v1/devices/pair, POST /v1/admin/devices/pairing-code, kiosk check-in/check-out/waiver/range-lanes/waitlist-cancel (${Environment})"
 
   ApiStage:
     Type: AWS::ApiGateway::Stage


### PR DESCRIPTION
## Summary

Exposes `POST /v1/admin/devices/pairing-code` via API Gateway (M-Next milestone), fixes a UUID type mismatch in the handler INSERT, and documents the desktop token bootstrap procedure in the kiosk provisioning runbook.

## Changes

- `infra/stacks/api-gateway.yaml` — adds `AdminDevicesPairingCode` resource, POST method (Cognito authorizer, Lambda proxy), OPTIONS preflight (CORS mock), and Lambda invoke permission scoped to the exact method ARN; bumps `DeploymentVersion` to trigger a new stage deployment
- `functions/admin/devices-pairing-code/handler.py` — adds `::uuid` inline cast to the `range_id` parameter in the `devices` INSERT; RDS Data API passes string parameters as `text` by default, causing a `42804` type error against a `uuid` column
- `docs/runbooks/kiosk-provisioning.md` — adds Section 7 documenting the full CLI flow for generating a temporary pairing code from a desktop (admin ID token → pairing-code endpoint → devices/pair → device_token) to unblock positive-path kiosk endpoint testing before a physical tablet is provisioned

## Motivation

Unblocks kiosk bootstrap smoke testing (M1 positive-path validation) without requiring a provisioned tablet. Closes the only missing piece between a fresh dev environment and a working device token.

## Security considerations

Pre-PR security review (system agent) returned no Critical or High findings. Two Medium and one Low finding are noted below for follow-up:

- **[MEDIUM]** No DB-level uniqueness guard on `devices(location_tag)` for `Pending-Pairing` status — concurrent requests can bypass the application-layer conflict check and insert two rows for the same location. Fix: partial unique index in a follow-up migration.
- **[MEDIUM]** `location_tag` is not stripped of whitespace before the conflict SELECT — a trailing space produces a distinct DB value and bypasses the 409 guard. Fix: `.strip()` on `location_tag` in a follow-up handler patch.
- **[LOW]** Runbook Section 7 says to revoke the test device "when [the Admin Portal] is available" — no fallback CLI revocation path is documented for the window before the portal ships. Fix: add a `curl` revocation step to the runbook in a follow-up docs PR.

The new API Gateway route has `AuthorizationType: COGNITO_USER_POOLS` on the POST method; Level 6 enforcement happens inside the Lambda. The OPTIONS preflight correctly uses `AuthorizationType: NONE`. The Lambda invoke permission is scoped to the exact path and method. No `training_level` is read from the JWT claim.

## Testing

- cfn-lint: no errors
- pytest: 306 passed in 0.71s
- pymarkdown: no errors
- End-to-end smoke (dev): `POST /v1/admin/devices/pairing-code` with a Level 6 ID token returned HTTP 201 with `device_id`, `pairing_code`, and `expires_at`
